### PR TITLE
Fix clear_on_drop's version.

### DIFF
--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -28,6 +28,9 @@ sha3 = { version = "0.8", default-features = false }
 rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
 rand_core = { version = "0.5", default-features = false, features = ["alloc"] }
 zeroize = { version = "1.1", default-features = false }
+# Force the dependency graph to use an older version of clear_on_drop.
+clear_on_drop = { version = "= 0.2.3", default-features = false }
+
 # Use avx2_backend for avx2 optimizations.
 curve25519-dalek = { version = "2.0.0", features = ["u64_backend", "alloc", "serde"], default-features = false }
 schnorrkel = { version = "0.9.1", features = ["u64_backend", "wasm-bindgen"], default-features = false }


### PR DESCRIPTION
Even though we don't use `clear_on_drop` (we use `Zeroize` for zeroizing secret data before an object is dropped), Dalek's bulletproof library depends uses it, an update to this crate broke our builds last night. Fixing its version in our dependency graph to one version older fixes the problem. We should monitor their releases in case they fix it. See the story for more detail.