### PR TITLE
Bring benchmarks back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Cargo.lock
 **/db_dir
 **/on-chain
 **/off-chain
+
+# Ignore the `crypto-framework` submodule
+crypto-framework/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,23 +38,23 @@ bulletproofs = { git = "https://github.com/fmiguelgarcia/bulletproofs.git", tag 
 wasm-bindgen-test = { version = "0.3.10"}
 
 [features]
-default = ["std", "avx2_backend"] 
+default = ["std", "avx2_backend"]
 
 # Backends
-u32_backend = [ 
-	"curve25519-dalek/u32_backend", 
+u32_backend = [
+	"curve25519-dalek/u32_backend",
 	"schnorrkel/u32_backend",
 	"bulletproofs/u32_backend"
 ]
-u64_backend = [ 
-	"curve25519-dalek/u64_backend", 
+u64_backend = [
+	"curve25519-dalek/u64_backend",
 	"schnorrkel/u64_backend",
 	"bulletproofs/u64_backend"
 ]
-avx2_backend = [ 
-	"curve25519-dalek/avx2_backend", 
+avx2_backend = [
+	"curve25519-dalek/avx2_backend",
 	"schnorrkel/avx2_backend",
-	"bulletproofs/avx2_backend" 
+	"bulletproofs/avx2_backend"
 ]
 
 serde_all = [
@@ -93,4 +93,16 @@ harness = false
 
 [[bench]]
 name = "membership_verification"
+harness = false
+
+[[bench]]
+name = "mercat_account"
+harness = false
+
+[[bench]]
+name = "mercat_asset"
+harness = false
+
+[[bench]]
+name = "mercat_transaction"
 harness = false

--- a/benches/mercat_asset.rs
+++ b/benches/mercat_asset.rs
@@ -15,9 +15,7 @@ use rand::thread_rng;
 // The issued amount. Will be in:
 // [10^MIN_ISSUER_AMOUNT_ORDER, 10^(MIN_ISSUER_AMOUNT_ORDER+1), ..., 10^MAX_ISSUER_AMOUNT_ORDER]
 const MIN_ISSUED_AMOUNT_ORDER: u32 = 1;
-const MAX_ISSUED_AMOUNT_ORDER: u32 = 5;
-
-// const ISSUED_AMOUNT: u32 = 1000;
+const MAX_ISSUED_AMOUNT_ORDER: u32 = 7;
 
 // The size of the valid asset id set.
 const MAX_ASSET_ID_INDEX: u32 = 1000000;

--- a/benches/mercat_transaction.rs
+++ b/benches/mercat_transaction.rs
@@ -16,7 +16,7 @@ use rand::thread_rng;
 // [10^MIN_SENDER_BALANCE_ORDER, 10^(MIN_SENDER_BALANCE_ORDER+1), ..., 10^MAX_SENDER_BALANCE_ORDER]
 // The transferred amout on each iteration will be all the balance the sender has: 10^SENDER_BALANCE_ORDER
 const MIN_SENDER_BALANCE_ORDER: u32 = 1;
-const MAX_SENDER_BALANCE_ORDER: u32 = 5;
+const MAX_SENDER_BALANCE_ORDER: u32 = 7;
 
 // The receiver's initial balance.
 const RECEIVER_INIT_BALANCE: u32 = 10000;


### PR DESCRIPTION
Adds the benchmarks back to the cargo.toml. increases the iterations to cover 1M asset transfers.