### PR TITLE
Constant time Elgamal Encryption 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ criterion = { version = "0.3", optional = true }
 lazy_static = { version = "1.4.0", default-features = false, features = ["spin_no_std"] }
 failure = { version = "0.1.7", default-features = false, features = ["derive"] }
 log = { version = "0.4.8" }
+byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 
 # Crypto
 sha3 = { version = "0.8", default-features = false }

--- a/benches/mercat_transaction.rs
+++ b/benches/mercat_transaction.rs
@@ -4,9 +4,10 @@ use cryptography::{
     mercat::{
         account::convert_asset_ids,
         transaction::{CtxMediator, CtxReceiver, CtxSender, TransactionValidator},
-        Account, EncryptionPubKey, FinalizedTransferTx, InitializedTransferTx, JustifiedTransferTx,
-        MediatorAccount, PubAccount, SigningPubKey, TransferTransactionMediator,
-        TransferTransactionReceiver, TransferTransactionSender, TransferTransactionVerifier,
+        Account, EncryptedAmount, EncryptionPubKey, FinalizedTransferTx, InitializedTransferTx,
+        JustifiedTransferTx, MediatorAccount, PubAccount, SigningPubKey,
+        TransferTransactionMediator, TransferTransactionReceiver, TransferTransactionSender,
+        TransferTransactionVerifier,
     },
     AssetId,
 };
@@ -29,32 +30,35 @@ const ASSET_ID: u32 = 1;
 
 fn bench_transaction_sender(
     c: &mut Criterion,
-    sender_accounts: Vec<Account>,
-    rcvr_pub_account: &PubAccount,
+    sender_account: Account,
+    sender_balances: Vec<EncryptedAmount>,
+    rcvr_pub_account: PubAccount,
     mdtr_pub_key: EncryptionPubKey,
 ) -> Vec<InitializedTransferTx> {
     let label = format!("MERCAT Transaction: Sender");
     let mut rng = thread_rng();
     let rcvr_pub_account = rcvr_pub_account.clone();
     let rcvr_pub_account_cloned = rcvr_pub_account.clone();
+    let sender_account_cloned = sender_account.clone();
 
-    let indexed_transaction: Vec<(u32, Account)> = (MIN_SENDER_BALANCE_ORDER
+    let indexed_transaction: Vec<(u32, EncryptedAmount)> = (MIN_SENDER_BALANCE_ORDER
         ..MAX_SENDER_BALANCE_ORDER)
         .map(|i| 10u32.pow(i))
-        .zip(sender_accounts.clone())
+        .zip(sender_balances.clone())
         .collect();
     let tx_id = 0;
 
     c.bench_function_over_inputs(
         &label,
-        move |b, (amount, sender_account)| {
+        move |b, (amount, sender_balance)| {
             b.iter(|| {
                 let sender = CtxSender {};
                 sender
                     .create_transaction(
                         tx_id,
-                        &sender_account.clone(),
-                        &rcvr_pub_account_cloned.clone(),
+                        &sender_account_cloned,
+                        sender_balance,
+                        &rcvr_pub_account_cloned,
                         &mdtr_pub_key.clone(),
                         &[],
                         amount.clone(),
@@ -68,13 +72,14 @@ fn bench_transaction_sender(
 
     indexed_transaction
         .iter()
-        .map(|(amount, sender_account)| {
+        .map(|(amount, sender_balance)| {
             let ctx_sender = CtxSender {};
             ctx_sender
                 .create_transaction(
                     tx_id,
                     &sender_account.clone(),
-                    &rcvr_pub_account.clone(),
+                    sender_balance,
+                    &rcvr_pub_account,
                     &mdtr_pub_key.clone(),
                     &[],
                     amount.clone(),
@@ -144,7 +149,8 @@ fn bench_transaction_receiver(
 fn bench_transaction_mediator(
     c: &mut Criterion,
     mediator_account: MediatorAccount,
-    sender_pub_accounts: Vec<PubAccount>,
+    sender_pub_account: PubAccount,
+    sender_pub_balances: Vec<EncryptedAmount>,
     receiver_pub_account: PubAccount,
     transactions: Vec<FinalizedTransferTx>,
     asset_id: AssetId,
@@ -153,19 +159,20 @@ fn bench_transaction_mediator(
     let mut rng = thread_rng();
     let mediator_account_cloned = mediator_account.clone();
     let receiver_pub_account_cloned = receiver_pub_account.clone();
+    let sender_pub_account_cloned = sender_pub_account.clone();
     let asset_id_cloned = asset_id.clone();
 
-    let indexed_transaction: Vec<((String, PubAccount), FinalizedTransferTx)> =
+    let indexed_transaction: Vec<((String, EncryptedAmount), FinalizedTransferTx)> =
         (MIN_SENDER_BALANCE_ORDER..MAX_SENDER_BALANCE_ORDER)
             .map(|i| format!("initial_balance ({:?})", 10u32.pow(i)))
-            .zip(sender_pub_accounts.clone())
+            .zip(sender_pub_balances.clone())
             .zip(transactions.clone())
             .collect();
     let indexed_transaction_cloned = indexed_transaction.clone();
 
     c.bench_function_over_inputs(
         &label,
-        move |b, ((_label, sender), tx)| {
+        move |b, ((_label, sender_balance), tx)| {
             b.iter(|| {
                 let mediator = CtxMediator {};
                 mediator
@@ -173,9 +180,9 @@ fn bench_transaction_mediator(
                         tx.clone(),
                         &mediator_account_cloned.encryption_key,
                         &mediator_account_cloned.signing_key,
-                        &sender.clone(),
+                        &sender_pub_account_cloned,
+                        sender_balance,
                         &receiver_pub_account_cloned,
-                        sender.enc_balance,
                         &[],
                         asset_id_cloned.clone(),
                         &mut rng,
@@ -188,16 +195,16 @@ fn bench_transaction_mediator(
 
     indexed_transaction
         .iter()
-        .map(|((_, sender), tx)| {
+        .map(|((_, sender_balance), tx)| {
             let mediator = CtxMediator {};
             mediator
                 .justify_transaction(
                     tx.clone(),
                     &mediator_account.encryption_key,
                     &mediator_account.signing_key,
-                    &sender,
+                    &sender_pub_account,
+                    sender_balance,
                     &receiver_pub_account,
-                    sender.enc_balance,
                     &[],
                     asset_id.clone(),
                     &mut rng,
@@ -210,32 +217,35 @@ fn bench_transaction_mediator(
 fn bench_transaction_validator(
     c: &mut Criterion,
     mediator_pub_key: SigningPubKey,
-    sender_pub_accounts: Vec<PubAccount>,
-    rcvr_pub_account: PubAccount,
+    sender_pub_account: PubAccount,
+    sender_pub_balances: Vec<EncryptedAmount>,
+    receiver_pub_account: PubAccount,
+    receiver_balance: EncryptedAmount,
     transactions: Vec<JustifiedTransferTx>,
 ) {
     let label = format!("MERCAT Transaction: Validator");
     let mut rng = thread_rng();
 
-    let indexed_transaction: Vec<((String, PubAccount), JustifiedTransferTx)> =
+    let indexed_transaction: Vec<((String, EncryptedAmount), JustifiedTransferTx)> =
         (MIN_SENDER_BALANCE_ORDER..MAX_SENDER_BALANCE_ORDER)
             .map(|i| format!("initial_balance ({:?})", 10u32.pow(i)))
-            .zip(sender_pub_accounts.clone())
+            .zip(sender_pub_balances.clone())
             .zip(transactions.clone())
             .collect();
 
     c.bench_function_over_inputs(
         &label,
-        move |b, ((_label, sender), tx)| {
+        move |b, ((_label, sender_balance), tx)| {
             b.iter(|| {
                 let validator = TransactionValidator {};
                 validator
                     .verify_transaction(
                         &tx,
-                        sender.clone(),
-                        rcvr_pub_account.clone(),
+                        &sender_pub_account,
+                        sender_balance,
+                        &receiver_pub_account,
+                        &receiver_balance,
                         &mediator_pub_key,
-                        sender.enc_balance,
                         &[],
                         &mut rng,
                     )
@@ -255,47 +265,33 @@ fn bench_transaction(c: &mut Criterion) {
 
     let mut rng = thread_rng();
     let (public_account, private_account) = utility::generate_mediator_keys(&mut rng);
-    let sender_account = utility::create_account_with_amount(
-        &mut rng,
-        &asset_id,
-        &valid_asset_ids,
-        &private_account,
-        &public_account,
-        0,
-    );
+    let (sender_account, sender_init_balance) =
+        utility::create_account_with_amount(&mut rng, &asset_id, &valid_asset_ids, 0);
+    let sender_pub_account = sender_account.pblc.clone();
 
     // Create a receiver account and load it with some assets.
-    let receiver_account = utility::create_account_with_amount(
+    let (receiver_account, receiver_balance) = utility::create_account_with_amount(
         &mut rng,
         &asset_id,
         &valid_asset_ids,
-        &private_account,
-        &public_account,
         RECEIVER_INIT_BALANCE,
     );
 
     // Make (Max - Min) sender accounts with initial balances of: [10^Min, 10^2, ..., 10^(Max-1)]
-    let sender_accounts: Vec<Account> = (MIN_SENDER_BALANCE_ORDER..MAX_SENDER_BALANCE_ORDER)
+    let sender_balances: Vec<EncryptedAmount> = (MIN_SENDER_BALANCE_ORDER
+        ..MAX_SENDER_BALANCE_ORDER)
         .map(|i| {
             let value = 10u32.pow(i);
-            Account {
-                scrt: sender_account.scrt.clone(),
-                pblc: utility::issue_assets(
-                    &mut rng,
-                    sender_account.clone(),
-                    &private_account,
-                    &public_account,
-                    value,
-                ),
-            }
+            utility::issue_assets(&mut rng, &sender_pub_account, &sender_init_balance, value)
         })
         .collect();
 
     // Initialization
     let transactions: Vec<InitializedTransferTx> = bench_transaction_sender(
         c,
-        sender_accounts.clone(),
-        &receiver_account.pblc,
+        sender_account.clone(),
+        sender_balances.clone(),
+        receiver_account.pblc.clone(),
         public_account.owner_enc_pub_key,
     );
 
@@ -308,15 +304,11 @@ fn bench_transaction(c: &mut Criterion) {
     );
 
     // Justification
-    let sender_pub_accounts: Vec<PubAccount> = sender_accounts
-        .iter()
-        .map(|account| account.pblc.clone())
-        .collect();
-
     let justified_transaction: Vec<JustifiedTransferTx> = bench_transaction_mediator(
         c,
         private_account,
-        sender_pub_accounts.clone(),
+        sender_pub_account.clone(),
+        sender_balances.clone(),
         receiver_account.pblc.clone(),
         finalized_transactions,
         asset_id,
@@ -326,8 +318,10 @@ fn bench_transaction(c: &mut Criterion) {
     bench_transaction_validator(
         c,
         public_account.owner_sign_pub_key,
-        sender_pub_accounts,
+        sender_pub_account,
+        sender_balances,
         receiver_account.pblc,
+        receiver_balance,
         justified_transaction,
     );
 }

--- a/src/asset_proofs/const_time_elgamal_encryption.rs
+++ b/src/asset_proofs/const_time_elgamal_encryption.rs
@@ -167,26 +167,6 @@ impl ElgamalSecretKey {
 }
 
 // ------------------------------------------------------------------------
-// CipherTextWithHint Refreshment Method
-// ------------------------------------------------------------------------
-
-impl CipherTextWithHint {
-    pub fn refresh<R: RngCore + CryptoRng>(
-        &self,
-        secret_key: &ElgamalSecretKey,
-        blinding: Scalar,
-        rng: &mut R,
-    ) -> Fallible<CipherTextWithHint> {
-        let value: Scalar = secret_key.const_time_decrypt(self)?.into();
-        let pub_key = secret_key.get_public_key();
-        let new_witness = CommitmentWitness::new(value, blinding);
-        let new_ciphertext = pub_key.const_time_encrypt(&new_witness, rng);
-
-        Ok(new_ciphertext)
-    }
-}
-
-// ------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------
 

--- a/src/asset_proofs/const_time_elgamal_encryption.rs
+++ b/src/asset_proofs/const_time_elgamal_encryption.rs
@@ -1,0 +1,191 @@
+//! The `const_time_elgamal_encryption` library implements the
+//! Constant Time Elgamal encryption over the Ristretto 25519 curve.
+
+use bulletproofs::PedersenGens;
+use curve25519_dalek::{
+    ristretto::{CompressedRistretto, RistrettoPoint},
+    scalar::Scalar,
+};
+use rand_core::{CryptoRng, RngCore};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use codec::{Decode, Encode, Error as CodecError, Input, Output};
+use sha3::{digest::FixedOutput, Digest, Sha3_256};
+use sp_std::prelude::*;
+
+use crate::asset_proofs::elgamal_encryption::{
+    CipherText, CommitmentWitness, ElgamalPublicKey, ElgamalSecretKey,
+};
+
+use crate::errors::Fallible;
+
+#[derive(PartialEq, Copy, Clone, Default)]
+#[cfg_attr(feature = "std", derive(Debug))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct CipherTextWithHint {
+    // The twisted Elgamal cipher text.
+    pub elgamal_cipher: CipherText,
+
+    pub y: RistrettoPoint,
+    pub z: [u8; 32],
+}
+
+impl Encode for CipherTextWithHint {
+    #[inline]
+    fn size_hint(&self) -> usize {
+        self.elgamal_cipher.size_hint() + 2 * 32
+    }
+
+    fn encode_to<W: Output>(&self, dest: &mut W) {
+        let y = self.y.compress();
+
+        self.elgamal_cipher.encode_to(dest);
+        y.as_bytes().encode_to(dest);
+        self.z.encode_to(dest);
+    }
+}
+
+impl Decode for CipherTextWithHint {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, CodecError> {
+        let (elgamal_cipher, y, z) = <(CipherText, [u8; 32], [u8; 32])>::decode(input)?;
+        let y = CompressedRistretto(y)
+            .decompress()
+            .ok_or_else(|| CodecError::from("CipherTextWithHint Y point is invalid"))?;
+
+        Ok(CipherTextWithHint {
+            elgamal_cipher,
+            y,
+            z,
+        })
+    }
+}
+
+// ------------------------------------------------------------------------
+// Constant Time Elgamal Encryption.
+// ------------------------------------------------------------------------
+
+/// Elgamal key pair:
+/// secret_key := scalar
+/// public_key := secret_key * g
+///
+/// Encryption:
+/// plaintext := (value, blinding_factor)
+/// cipher_text := (X, Y)
+/// X := blinding_factor * public_key
+/// Y := blinding_factor * g + value * h
+///
+/// Decryption:
+/// Given (secret_key, X, Y) find value such that:
+/// value * h = Y - X / secret_key
+///
+/// where g and h are 2 orthogonal generators.
+
+fn xor_with_one_time_pad(key: RistrettoPoint, data: &[u8; 32]) -> [u8; 32] {
+    let key_bytes: [u8; 32] = key.compress().to_bytes();
+    let hashed_key = Sha3_256::default().chain(key_bytes).fixed_result();
+
+    let mut result = [0u8; 32];
+    for index in 0..32 {
+        result[index] = hashed_key[index] ^ data[index];
+    }
+
+    result
+}
+
+impl ElgamalPublicKey {
+    // todo this could be renamed to constant_time_encrypt
+    pub fn const_time_encrypt<R: RngCore + CryptoRng>(
+        &self,
+        witness: &CommitmentWitness,
+        rng: &mut R,
+    ) -> CipherTextWithHint {
+        // Elgamal Encryption.
+        let elgamal_cipher = self.encrypt(witness);
+        let r1 = witness.blinding();
+
+        // Constant Time Elgamal.
+        let message_bytes: [u8; 32] = witness.value().to_bytes();
+        let r2 = Scalar::random(rng);
+        let gens = PedersenGens::default();
+        let r2h = r2 * gens.B;
+
+        let y = gens.commit(r2, r1); // r1 * g + r2 * h
+        let z = xor_with_one_time_pad(r2h, &message_bytes);
+
+        CipherTextWithHint {
+            elgamal_cipher,
+            y,
+            z,
+        }
+    }
+
+    pub fn const_time_encrypt_value<R: RngCore + CryptoRng>(
+        &self,
+        value: Scalar,
+        rng: &mut R,
+    ) -> (CommitmentWitness, CipherTextWithHint) {
+        let blinding = Scalar::random(rng);
+        let witness = CommitmentWitness::new(value, blinding);
+        let encrypted_witness = self.const_time_encrypt(&witness, rng);
+        (witness, encrypted_witness)
+    }
+}
+
+impl ElgamalSecretKey {
+    /// Decrypt a cipher text that is known to encrypt a u32.
+    pub fn const_time_decrypt(&self, cipher_text: &CipherTextWithHint) -> Fallible<u32> {
+        // value * h = Y - X / secret_key
+        let value_h = cipher_text.y - self.secret.invert() * cipher_text.elgamal_cipher.x;
+
+        use byteorder::{ByteOrder, LittleEndian};
+
+        let decrypted_msg = xor_with_one_time_pad(value_h, &cipher_text.z);
+        let decrypted_u32 = LittleEndian::read_u32(&decrypted_msg);
+
+        // Verify that the same value was encrypted using twisted Elgamal encryption.
+        self.verify(&cipher_text.elgamal_cipher, &decrypted_u32.into())?;
+        Ok(decrypted_u32)
+    }
+}
+
+// ------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    extern crate wasm_bindgen_test;
+    use super::*;
+    use crate::errors::ErrorKind;
+    use rand::{rngs::StdRng, SeedableRng};
+    use wasm_bindgen_test::*;
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn basic_const_time_elgamal_enc_dec() {
+        let mut rng = StdRng::from_seed([42u8; 32]);
+        let elg_secret = ElgamalSecretKey::new(Scalar::random(&mut rng));
+        let elg_pub = elg_secret.get_public_key();
+
+        // Test encrypt().
+        let values = vec![0u32, 1u32, 255u32, u32::MAX];
+        let _ = values.iter().map(|v| {
+            let (_, cipher) = elg_pub.const_time_encrypt_value(Scalar::from(*v), &mut rng);
+            let decrypted_v = elg_secret.const_time_decrypt(&cipher).unwrap();
+            assert_eq!(decrypted_v, *v);
+        });
+
+        // Negative test.
+        // If the message is altered, it won't decrypt.
+        let value = 111u32;
+        let (_, cipher) = elg_pub.const_time_encrypt_value(value.into(), &mut rng);
+        let mut corrupt_cipher = cipher.clone();
+        corrupt_cipher.z[0] += 1;
+        assert_err!(
+            elg_secret.const_time_decrypt(&corrupt_cipher),
+            ErrorKind::CipherTextDecryptionError
+        );
+    }
+}

--- a/src/asset_proofs/elgamal_encryption.rs
+++ b/src/asset_proofs/elgamal_encryption.rs
@@ -31,7 +31,7 @@ pub struct CommitmentWitness {
     /// balance value or the asset id in Scalar format.
     value: Scalar,
 
-    // A random blinding factor.
+    /// A random blinding factor.
     blinding: Scalar,
 }
 

--- a/src/asset_proofs/mod.rs
+++ b/src/asset_proofs/mod.rs
@@ -200,9 +200,7 @@
 pub(crate) mod macros;
 
 mod elgamal_encryption;
-pub use elgamal_encryption::{
-    encrypt_using_two_pub_keys, CipherText, CommitmentWitness, ElgamalPublicKey, ElgamalSecretKey,
-};
+pub use elgamal_encryption::{CipherText, CommitmentWitness, ElgamalPublicKey, ElgamalSecretKey};
 pub mod const_time_elgamal_encryption;
 pub use const_time_elgamal_encryption::CipherTextWithHint;
 

--- a/src/asset_proofs/mod.rs
+++ b/src/asset_proofs/mod.rs
@@ -203,6 +203,8 @@ mod elgamal_encryption;
 pub use elgamal_encryption::{
     encrypt_using_two_pub_keys, CipherText, CommitmentWitness, ElgamalPublicKey, ElgamalSecretKey,
 };
+pub mod const_time_elgamal_encryption;
+pub use const_time_elgamal_encryption::CipherTextWithHint;
 
 pub mod encryption_proofs;
 

--- a/src/asset_proofs/mod.rs
+++ b/src/asset_proofs/mod.rs
@@ -199,7 +199,7 @@
 #[macro_use]
 pub(crate) mod macros;
 
-mod elgamal_encryption;
+pub mod elgamal_encryption;
 pub use elgamal_encryption::{CipherText, CommitmentWitness, ElgamalPublicKey, ElgamalSecretKey};
 pub mod const_time_elgamal_encryption;
 pub use const_time_elgamal_encryption::CipherTextWithHint;

--- a/src/mercat/asset.rs
+++ b/src/mercat/asset.rs
@@ -68,7 +68,7 @@ fn asset_issuance_init_verify_proofs(
     single_property_verifier(
         &WellformednessVerifier {
             pub_key: issr_pub_account.memo.owner_enc_pub_key,
-            cipher: asset_tx.content.memo.enc_issued_amount.elgamal_cipher,
+            cipher: asset_tx.content.memo.enc_issued_amount,
             pc_gens: &gens,
         },
         asset_tx.content.balance_wellformedness_proof,
@@ -119,7 +119,7 @@ fn verify_auditor_payload(
                             &EncryptingSameValueVerifier {
                                 pub_key1: issuer_enc_pub_key,
                                 pub_key2: auditor_pub_key.clone(),
-                                cipher1: issuer_enc_amount.elgamal_cipher,
+                                cipher1: issuer_enc_amount,
                                 cipher2: payload.encrypted_amount.elgamal_cipher,
                                 pc_gens: &gens,
                             },
@@ -169,7 +169,7 @@ impl AssetTransactionIssuer for AssetIssuer {
             .scrt
             .enc_keys
             .pblc
-            .const_time_encrypt_value(amount.into(), rng);
+            .encrypt_value(amount.into(), rng);
         let memo = AssetMemo {
             enc_issued_amount: issr_enc_amount,
             tx_id,
@@ -373,8 +373,7 @@ impl AssetTransactionMediator for AssetMediator {
                 cipher: initialized_asset_tx
                     .content
                     .memo
-                    .enc_issued_amount
-                    .elgamal_cipher,
+                    .enc_issued_amount,
                 pc_gens: &gens,
             },
             initialized_asset_tx.content.balance_correctness_proof,
@@ -440,8 +439,7 @@ impl AssetTransactionAuditor for AssetAuditor {
                             cipher: initialized_asset_tx
                                 .content
                                 .memo
-                                .enc_issued_amount
-                                .elgamal_cipher,
+                                .enc_issued_amount,
                             pc_gens: &gens,
                         },
                         initialized_asset_tx.content.balance_correctness_proof,
@@ -627,7 +625,7 @@ mod tests {
         assert!(issuer_enc_key
             .scrt
             .verify(
-                &updated_issuer_account.enc_balance.elgamal_cipher,
+                &updated_issuer_account.enc_balance,
                 &issued_amount.into()
             )
             .is_ok());
@@ -746,7 +744,7 @@ mod tests {
         assert!(issuer_enc_key
             .scrt
             .verify(
-                &updated_issuer_account.enc_balance.elgamal_cipher,
+                &updated_issuer_account.enc_balance,
                 &issued_amount.into()
             )
             .is_ok());

--- a/src/mercat/asset.rs
+++ b/src/mercat/asset.rs
@@ -370,10 +370,7 @@ impl AssetTransactionMediator for AssetMediator {
             &CorrectnessVerifier {
                 value: amount.into(),
                 pub_key: issr_pub_account.memo.owner_enc_pub_key,
-                cipher: initialized_asset_tx
-                    .content
-                    .memo
-                    .enc_issued_amount,
+                cipher: initialized_asset_tx.content.memo.enc_issued_amount,
                 pc_gens: &gens,
             },
             initialized_asset_tx.content.balance_correctness_proof,
@@ -436,10 +433,7 @@ impl AssetTransactionAuditor for AssetAuditor {
                         &CorrectnessVerifier {
                             value: amount.into(),
                             pub_key: issuer_account.memo.owner_enc_pub_key,
-                            cipher: initialized_asset_tx
-                                .content
-                                .memo
-                                .enc_issued_amount,
+                            cipher: initialized_asset_tx.content.memo.enc_issued_amount,
                             pc_gens: &gens,
                         },
                         initialized_asset_tx.content.balance_correctness_proof,
@@ -624,10 +618,7 @@ mod tests {
         // Check that the issued amount is added to the account balance.
         assert!(issuer_enc_key
             .scrt
-            .verify(
-                &updated_issuer_account.enc_balance,
-                &issued_amount.into()
-            )
+            .verify(&updated_issuer_account.enc_balance, &issued_amount.into())
             .is_ok());
 
         // Check that the asset_id is still the same.
@@ -743,10 +734,7 @@ mod tests {
         // Check that the issued amount is added to the account balance.
         assert!(issuer_enc_key
             .scrt
-            .verify(
-                &updated_issuer_account.enc_balance,
-                &issued_amount.into()
-            )
+            .verify(&updated_issuer_account.enc_balance, &issued_amount.into())
             .is_ok());
 
         // Check that the asset_id is still the same.

--- a/src/mercat/mod.rs
+++ b/src/mercat/mod.rs
@@ -11,8 +11,8 @@ use crate::{
         correctness_proof::CorrectnessProof,
         encrypting_same_value_proof::CipherEqualDifferentPubKeyProof,
         membership_proof::MembershipProof, range_proof::InRangeProof,
-        wellformedness_proof::WellformednessProof, CipherText, CommitmentWitness, ElgamalPublicKey,
-        ElgamalSecretKey,
+        wellformedness_proof::WellformednessProof, CipherText, CipherTextWithHint,
+        CommitmentWitness, ElgamalPublicKey, ElgamalSecretKey,
     },
     errors::Fallible,
     AssetId, Balance,
@@ -65,6 +65,7 @@ pub type Signature = schnorrkel::sign::Signature;
 pub type EncryptedAssetId = CipherText;
 
 /// New type for Twisted ElGamal ciphertext of account amounts/balances.
+// pub type EncryptedAmount = CipherTextWithHint;
 pub type EncryptedAmount = CipherText;
 
 /// Asset memo holds the contents of an asset issuance transaction.

--- a/src/mercat/mod.rs
+++ b/src/mercat/mod.rs
@@ -274,11 +274,7 @@ impl Account {
     /// Utility method that can decrypt the the balance of an account.
     /// Note that this decryption is not constant time.
     pub fn decrypt_balance(&self) -> Fallible<Balance> {
-        let balance = self
-            .scrt
-            .enc_keys
-            .scrt
-            .decrypt(&self.pblc.enc_balance)?;
+        let balance = self.scrt.enc_keys.scrt.decrypt(&self.pblc.enc_balance)?;
 
         Ok(Balance::from(balance))
     }

--- a/src/mercat/mod.rs
+++ b/src/mercat/mod.rs
@@ -65,7 +65,10 @@ pub type Signature = schnorrkel::sign::Signature;
 pub type EncryptedAssetId = CipherText;
 
 /// New type for Twisted ElGamal ciphertext of account amounts/balances.
-pub type EncryptedAmount = CipherTextWithHint;
+pub type EncryptedAmount = CipherText;
+
+/// New type for ElGamal ciphertext of a transferred amount.
+pub type EncryptedAmountWithHint = CipherTextWithHint;
 
 /// Asset memo holds the contents of an asset issuance transaction.
 #[derive(Clone, Encode, Decode)]
@@ -275,7 +278,7 @@ impl Account {
             .scrt
             .enc_keys
             .scrt
-            .decrypt(&self.pblc.enc_balance.elgamal_cipher)?;
+            .decrypt(&self.pblc.enc_balance)?;
 
         Ok(Balance::from(balance))
     }
@@ -411,7 +414,7 @@ impl core::fmt::Debug for TransferTxState {
 pub struct AssetTxContent {
     pub account_id: u32,
     pub enc_asset_id: EncryptedAssetId,
-    pub enc_amount_for_mdtr: EncryptedAmount,
+    pub enc_amount_for_mdtr: EncryptedAmountWithHint,
     pub memo: AssetMemo,
     pub asset_id_equal_cipher_proof: CipherEqualDifferentPubKeyProof,
     pub balance_wellformedness_proof: WellformednessProof,
@@ -545,7 +548,7 @@ pub trait AssetTransactionAuditor {
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct AuditorPayload {
     pub auditor_id: u32,
-    pub encrypted_amount: EncryptedAmount,
+    pub encrypted_amount: EncryptedAmountWithHint,
     pub amount_equal_cipher_proof: CipherEqualDifferentPubKeyProof,
 }
 
@@ -562,7 +565,7 @@ pub struct TransferTxMemo {
     pub refreshed_enc_asset_id: EncryptedAssetId,
     pub enc_asset_id_using_rcvr: EncryptedAssetId,
     pub enc_asset_id_for_mdtr: EncryptedAssetId,
-    pub enc_amount_for_mdtr: EncryptedAmount,
+    pub enc_amount_for_mdtr: EncryptedAmountWithHint,
     pub tx_id: u32,
 }
 
@@ -731,7 +734,7 @@ pub trait TransferTransactionMediator {
         mdtr_sign_keys: &SigningKeys,
         sndr_account: &PubAccount,
         rcvr_account: &PubAccount,
-        pending_balance: EncryptedAmount,
+        pending_balance: EncryptedAmount, // todo
         auditors_enc_pub_keys: &[(u32, EncryptionPubKey)],
         asset_id_hint: AssetId,
         rng: &mut R,
@@ -747,7 +750,7 @@ pub trait TransferTransactionVerifier {
         sndr_account: PubAccount,
         rcvr_account: PubAccount,
         mdtr_sign_pub_key: &SigningPubKey,
-        pending_balance: EncryptedAmount,
+        pending_balance: EncryptedAmount, // todo
         auditors_enc_pub_keys: &[(u32, EncryptionPubKey)],
         rng: &mut R,
     ) -> Fallible<(PubAccount, PubAccount)>;

--- a/src/mercat/mod.rs
+++ b/src/mercat/mod.rs
@@ -65,8 +65,7 @@ pub type Signature = schnorrkel::sign::Signature;
 pub type EncryptedAssetId = CipherText;
 
 /// New type for Twisted ElGamal ciphertext of account amounts/balances.
-// pub type EncryptedAmount = CipherTextWithHint;
-pub type EncryptedAmount = CipherText;
+pub type EncryptedAmount = CipherTextWithHint;
 
 /// Asset memo holds the contents of an asset issuance transaction.
 #[derive(Clone, Encode, Decode)]
@@ -270,8 +269,13 @@ pub struct Account {
 
 impl Account {
     /// Utility method that can decrypt the the balance of an account.
+    /// Note that this decryption is not constant time.
     pub fn decrypt_balance(&self) -> Fallible<Balance> {
-        let balance = self.scrt.enc_keys.scrt.decrypt(&self.pblc.enc_balance)?;
+        let balance = self
+            .scrt
+            .enc_keys
+            .scrt
+            .decrypt(&self.pblc.enc_balance.elgamal_cipher)?;
 
         Ok(Balance::from(balance))
     }


### PR DESCRIPTION
Addresses CRYP 126. 
Note that since regular Elgamal is not homomorphic depositing or withdrawing an EncryptedAmount will invalidate the regular Elgamal cipher text.