### PR TITLE
Enable debug in both std and non-std

### DIFF
--- a/src/asset_proofs/ciphertext_refreshment_proof.rs
+++ b/src/asset_proofs/ciphertext_refreshment_proof.rs
@@ -43,9 +43,8 @@ pub const CIPHERTEXT_REFRESHMENT_PROOF_CHALLENGE_LABEL: &[u8] =
 // public key
 // ------------------------------------------------------------------------
 
-#[derive(PartialEq, Copy, Clone, Default)]
+#[derive(PartialEq, Copy, Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct CipherTextRefreshmentFinalResponse(Scalar);
 
 impl Encode for CipherTextRefreshmentFinalResponse {
@@ -71,9 +70,8 @@ impl Decode for CipherTextRefreshmentFinalResponse {
     }
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct CipherTextRefreshmentInitialMessage {
     a: RistrettoPoint,
     b: RistrettoPoint,

--- a/src/asset_proofs/const_time_elgamal_encryption.rs
+++ b/src/asset_proofs/const_time_elgamal_encryption.rs
@@ -53,8 +53,7 @@ use crate::errors::Fallible;
 /// Note that we can not only rely on regular Elgamal encryption since
 /// 1. it is not homomorphic. 2. all asset proofs prove properties of
 /// a twisted Elgamal cipher text.
-#[derive(PartialEq, Copy, Clone, Default)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(PartialEq, Copy, Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CipherTextWithHint {
     // The twisted Elgamal cipher text.

--- a/src/asset_proofs/elgamal_encryption.rs
+++ b/src/asset_proofs/elgamal_encryption.rs
@@ -22,9 +22,8 @@ use codec::{Decode, Encode, Error as CodecError, Input, Output};
 use sp_std::prelude::*;
 
 /// Prover's representation of the commitment secret.
-#[derive(Clone, PartialEq, Zeroize)]
+#[derive(Clone, PartialEq, Zeroize, Debug)]
 #[zeroize(drop)]
-#[cfg_attr(feature = "std", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CommitmentWitness {
     /// Depending on how the witness was created this variable stores the
@@ -88,8 +87,7 @@ impl Decode for CommitmentWitness {
 }
 
 /// Prover's representation of the encrypted secret.
-#[derive(PartialEq, Copy, Clone, Default)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(PartialEq, Copy, Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CipherText {
     pub x: RistrettoPoint,
@@ -188,9 +186,8 @@ define_sub_assign_variants!(LHS = CipherText, RHS = CipherText);
 /// where g and h are 2 orthogonal generators.
 
 /// An Elgamal Secret Key is a random scalar.
-#[derive(Clone, Zeroize)]
+#[derive(Clone, Zeroize, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 #[zeroize(drop)]
 pub struct ElgamalSecretKey {
     pub secret: Scalar,
@@ -218,9 +215,8 @@ impl Decode for ElgamalSecretKey {
 }
 
 /// The Elgamal Public Key is the secret key multiplied by the blinding generator (g).
-#[derive(Copy, Clone, Default, PartialEq)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct ElgamalPublicKey {
     pub pub_key: RistrettoPoint,
 }

--- a/src/asset_proofs/encrypting_same_value_proof.rs
+++ b/src/asset_proofs/encrypting_same_value_proof.rs
@@ -40,9 +40,8 @@ pub const ENCRYPTING_SAME_VALUE_PROOF_CHALLENGE_LABEL: &[u8] =
 // Public Keys
 // ------------------------------------------------------------------------
 
-#[derive(PartialEq, Copy, Clone, Default)]
+#[derive(PartialEq, Copy, Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct EncryptingSameValueFinalResponse {
     z1: Scalar,
     z2: Scalar,
@@ -71,9 +70,8 @@ impl Decode for EncryptingSameValueFinalResponse {
     }
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct EncryptingSameValueInitialMessage {
     a1: RistrettoPoint,
     a2: RistrettoPoint,

--- a/src/asset_proofs/range_proof.rs
+++ b/src/asset_proofs/range_proof.rs
@@ -25,9 +25,8 @@ pub type RangeProofInitialMessage = CompressedRistretto;
 pub type RangeProofFinalResponse = RangeProof;
 
 /// Holds the non-interactive range proofs, equivalent of L_range of MERCAT paper.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct InRangeProof {
     pub init: RangeProofInitialMessage,
     pub response: RangeProofFinalResponse,

--- a/src/asset_proofs/wellformedness_proof.rs
+++ b/src/asset_proofs/wellformedness_proof.rs
@@ -34,9 +34,8 @@ pub const WELLFORMEDNESS_PROOF_FINAL_RESPONSE_LABEL: &[u8] = b"PolymathWellforme
 /// The domain label for the challenge.
 pub const WELLFORMEDNESS_PROOF_CHALLENGE_LABEL: &[u8] = b"PolymathWellformednessProofChallenge";
 
-#[derive(PartialEq, Copy, Clone, Default)]
+#[derive(PartialEq, Copy, Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct WellformednessFinalResponse {
     z1: Scalar,
     z2: Scalar,
@@ -68,9 +67,8 @@ impl Decode for WellformednessFinalResponse {
     }
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct WellformednessInitialMessage {
     a: RistrettoPoint,
     b: RistrettoPoint,
@@ -127,8 +125,7 @@ impl UpdateTranscript for WellformednessInitialMessage {
 pub type WellformednessProof =
     ZKProofResponse<WellformednessInitialMessage, WellformednessFinalResponse>;
 
-#[derive(Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Debug)]
 pub struct WellformednessProver {
     /// The secret commitment witness.
     w: Zeroizing<CommitmentWitness>,

--- a/src/mercat/asset.rs
+++ b/src/mercat/asset.rs
@@ -354,8 +354,7 @@ impl AssetTransactionMediator for AssetMediator {
 // ------------------------------------------------------------------------------------------------
 
 /// Asset transaction auditor.
-#[derive(Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Debug)]
 pub struct AssetAuditor {}
 
 impl AssetTransactionAuditor for AssetAuditor {

--- a/src/mercat/mod.rs
+++ b/src/mercat/mod.rs
@@ -44,9 +44,8 @@ pub type EncryptionPubKey = ElgamalPublicKey;
 pub type EncryptionSecKey = ElgamalSecretKey;
 
 /// Holds ElGamal encryption keys.
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct EncryptionKeys {
     pub pblc: EncryptionPubKey,
     pub scrt: EncryptionSecKey,
@@ -65,16 +64,14 @@ pub type EncryptedAmountWithHint = CipherTextWithHint;
 // -                                    Account                                        -
 // -------------------------------------------------------------------------------------
 
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct MediatorAccount {
     pub encryption_key: EncryptionKeys,
 }
 
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Encode, Decode, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct PubAccount {
     pub id: u32,
     pub enc_asset_id: EncryptedAssetId,
@@ -82,9 +79,8 @@ pub struct PubAccount {
 }
 
 /// Holds contents of the public portion of an account which can be safely put on the chain.
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Encode, Decode, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct PubAccountTx {
     pub pub_account: PubAccount,
     pub initial_balance: EncryptedAmount,
@@ -95,17 +91,15 @@ pub struct PubAccountTx {
 }
 
 /// Holds the secret keys and asset id of an account. This cannot be put on the change.
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct SecAccount {
     pub enc_keys: EncryptionKeys,
     pub asset_id_witness: CommitmentWitness,
 }
 
 /// Wrapper for both the secret and public account info
-#[derive(Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Debug)]
 pub struct Account {
     pub pblc: PubAccount,
     pub scrt: SecAccount,
@@ -234,9 +228,8 @@ impl core::fmt::Debug for TransferTxState {
 // -------------------------------------------------------------------------------------
 
 /// Asset memo holds the contents of an asset issuance transaction.
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct AssetMemo {
     pub enc_issued_amount: EncryptedAmount,
     pub tx_id: u32,
@@ -244,9 +237,8 @@ pub struct AssetMemo {
 
 /// Holds the public portion of an asset issuance transaction after initialization.
 /// This can be placed on the chain.
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct InitializedAssetTx {
     pub account_id: u32,
     pub enc_asset_id: EncryptedAssetId,
@@ -258,9 +250,8 @@ pub struct InitializedAssetTx {
     pub auditors_payload: Vec<AuditorPayload>,
 }
 
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct JustifiedAssetTx {
     pub init_data: InitializedAssetTx,
 }
@@ -322,9 +313,8 @@ pub trait AssetTransactionAuditor {
 // -                       Confidential Transfer Transaction                           -
 // -------------------------------------------------------------------------------------
 
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct AuditorPayload {
     pub auditor_id: u32,
     pub encrypted_amount: EncryptedAmountWithHint,
@@ -332,9 +322,8 @@ pub struct AuditorPayload {
 }
 
 /// Holds the memo for confidential transaction sent by the sender.
-#[derive(Default, Clone, Copy, Encode, Decode)]
+#[derive(Default, Clone, Copy, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct TransferTxMemo {
     pub sndr_account_id: u32,
     pub rcvr_account_id: u32,
@@ -349,9 +338,8 @@ pub struct TransferTxMemo {
 }
 
 /// Holds the proofs and memo of the confidential transaction sent by the sender.
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct InitializedTransferTx {
     pub amount_equal_cipher_proof: CipherEqualDifferentPubKeyProof,
     pub non_neg_amount_proof: InRangeProof,
@@ -367,17 +355,15 @@ pub struct InitializedTransferTx {
 
 /// Holds the initial transaction data and the proof of equality of asset ids
 /// prepared by the receiver.
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct FinalizedTransferTx {
     pub init_data: InitializedTransferTx,
     pub asset_id_from_sndr_equal_to_rcvr_proof: CipherEqualSamePubKeyProof,
 }
 
 /// Wrapper for the contents and auditors' payload.
-#[derive(Clone, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Encode, Decode, Debug)]
 pub struct JustifiedTransferTx {
     pub finalized_data: FinalizedTransferTx,
 }

--- a/src/mercat/transaction.rs
+++ b/src/mercat/transaction.rs
@@ -36,8 +36,7 @@ use zeroize::Zeroizing;
 
 /// The sender of a confidential transaction. Sender creates a transaction
 /// and performs initial proofs.
-#[derive(Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Debug)]
 pub struct CtxSender {}
 
 impl TransferTransactionSender for CtxSender {
@@ -250,8 +249,7 @@ fn add_transaction_auditor<T: RngCore + CryptoRng>(
 
 /// The receiver of a confidential transaction. Receiver finalizes and processes
 /// transaction.
-#[derive(Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Debug)]
 pub struct CtxReceiver {}
 
 impl TransferTransactionReceiver for CtxReceiver {
@@ -305,8 +303,7 @@ impl TransferTransactionReceiver for CtxReceiver {
 // -                                           Mediator                                           -
 // ------------------------------------------------------------------------------------------------
 
-#[derive(Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Debug)]
 pub struct CtxMediator {}
 
 impl TransferTransactionMediator for CtxMediator {
@@ -381,8 +378,7 @@ impl TransferTransactionMediator for CtxMediator {
 // ------------------------------------------------------------------------------------------------
 
 /// Transaction Validator.
-#[derive(Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Debug)]
 pub struct TransactionValidator {}
 
 impl TransferTransactionVerifier for TransactionValidator {
@@ -610,8 +606,7 @@ fn verify_auditor_payload(
 // ------------------------------------------------------------------------------------------------
 
 /// Transaction Validator.
-#[derive(Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Debug)]
 pub struct CtxAuditor {}
 
 impl TransferTransactionAuditor for CtxAuditor {


### PR DESCRIPTION
Addresses CRYP-159

The requirement for having Debug only in std was removed from Polymesh https://github.com/PolymathNetwork/Polymesh/commit/c6df37e193bee4f6d663dd56fd7f9465fa81facd

Related PR: https://github.com/PolymathNetwork/Polymesh/pull/584