### PR TITLE
Remove RawData.

### DIFF
--- a/src/claim_proofs/claim_proofs.rs
+++ b/src/claim_proofs/claim_proofs.rs
@@ -11,7 +11,7 @@
 //!
 //! ```
 //! use cryptography::claim_proofs::{compute_cdd_id, compute_scope_id, build_scope_claim_proof_data,
-//!     CDDClaimData, ScopeClaimData, ProofKeyPair, RawData};
+//!     CDDClaimData, ScopeClaimData, ProofKeyPair};
 //! use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
 //!
 //! // Investor side:
@@ -55,16 +55,6 @@ const SIGNING_CTX: &[u8] = b"PolymathClaimProofs";
 
 lazy_static! {
     static ref SIG_CTXT: SigningContext = signing_context(SIGNING_CTX);
-}
-
-#[derive(Debug, Copy, Clone, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct RawData(pub [u8; 32]);
-
-impl AsRef<[u8; 32]> for RawData {
-    fn as_ref(&self) -> &[u8; 32] {
-        &self.0
-    }
 }
 
 /// The data needed to generate a CDD ID
@@ -265,8 +255,8 @@ mod tests {
     #[test]
     fn match_pub_key_both_sides() {
         let expected_public_key = [
-            84, 187, 123, 240, 45, 40, 230, 87, 26, 0, 180, 230, 181, 65, 112, 176, 228, 180, 167,
-            76, 81, 254, 147, 102, 152, 251, 26, 99, 100, 215, 129, 62,
+            220, 100, 91, 47, 92, 14, 0, 234, 127, 191, 5, 26, 248, 147, 212, 237, 161, 119, 64,
+            169, 83, 51, 41, 240, 233, 227, 181, 239, 109, 96, 202, 93,
         ];
 
         let mut rng = StdRng::from_seed(SEED_1);

--- a/src/claim_proofs/mod.rs
+++ b/src/claim_proofs/mod.rs
@@ -5,7 +5,7 @@
 pub mod claim_proofs;
 pub use claim_proofs::{
     build_scope_claim_proof_data, compute_cdd_id, compute_scope_id, CDDClaimData, ProofKeyPair,
-    ProofPublicKey, RawData, ScopeClaimData,
+    ProofPublicKey, ScopeClaimData,
 };
 
 pub mod pedersen_commitments;
@@ -14,26 +14,15 @@ pub use pedersen_commitments::PedersenGenerators;
 use curve25519_dalek::scalar::Scalar;
 use rand_core::{CryptoRng, RngCore};
 
-pub fn random_claim<R: RngCore + CryptoRng + ?Sized>(
-    rng: &mut R,
-) -> (CDDClaimData, ScopeClaimData) {
-    let mut investor_did = RawData::default();
-    let mut investor_unique_id = RawData::default();
-    let mut scope_did = RawData::default();
-
-    rng.fill_bytes(&mut investor_did.0);
-    rng.fill_bytes(&mut investor_unique_id.0);
-    rng.fill_bytes(&mut scope_did.0);
-
-    let investor_unique_id = Scalar::from_bits(investor_unique_id.0);
-
+pub fn random_claim<R: RngCore + CryptoRng>(rng: &mut R) -> (CDDClaimData, ScopeClaimData) {
+    let investor_unique_id = Scalar::random(rng);
     (
         CDDClaimData {
-            investor_did: Scalar::from_bits(investor_did.0),
+            investor_did: Scalar::random(rng),
             investor_unique_id,
         },
         ScopeClaimData {
-            scope_did: Scalar::from_bits(scope_did.0),
+            scope_did: Scalar::random(rng),
             investor_unique_id,
         },
     )


### PR DESCRIPTION
The leftover RawData structure was used in the `random_claim()` helper function. when the outputted random claims were serialized, they couldn't be properly deserialized as a Scalar.