### PR TITLE
Changes due to integrating asset minting to Polymesh

### DIFF
--- a/benches/mercat_account.rs
+++ b/benches/mercat_account.rs
@@ -23,7 +23,6 @@ fn bench_account_creation(c: &mut Criterion) {
 
     let mut rng = thread_rng();
     let tx_id = 0;
-    let account_id = 0;
 
     let label = "MERCAT Transaction: Creator".to_string();
     let secret_accounts: Vec<(String, SecAccount)> = ASSET_IDS
@@ -41,13 +40,7 @@ fn bench_account_creation(c: &mut Criterion) {
             b.iter(|| {
                 let account_creator = AccountCreator {};
                 account_creator
-                    .create(
-                        tx_id,
-                        &secret_account,
-                        &valid_asset_ids,
-                        account_id,
-                        &mut rng,
-                    )
+                    .create(tx_id, &secret_account, &valid_asset_ids, &mut rng)
                     .unwrap();
             })
         },
@@ -63,7 +56,6 @@ fn bench_account_creation(c: &mut Criterion) {
                     &mut rng,
                     &AssetId::from(id),
                     &valid_asset_ids_cloned,
-                    account_id,
                     tx_id,
                 ),
             )

--- a/benches/utility.rs
+++ b/benches/utility.rs
@@ -52,7 +52,7 @@ pub fn create_account_with_amount<R: RngCore + CryptoRng>(
     let tx_id = 0;
     let account_creator = AccountCreator {};
     let pub_account_tx = account_creator
-        .create(tx_id, &secret_account, valid_asset_ids, 0, rng)
+        .create(tx_id, &secret_account, valid_asset_ids, rng)
         .unwrap();
     let account = Account {
         scrt: secret_account,
@@ -77,14 +77,13 @@ pub fn create_account<R: RngCore + CryptoRng>(
     rng: &mut R,
     asset_id: &AssetId,
     valid_asset_ids: &Vec<Scalar>,
-    account_id: u32,
     tx_id: u32,
 ) -> PubAccountTx {
     let secret_account = gen_keys(rng, asset_id);
 
     let account_creator = AccountCreator {};
     account_creator
-        .create(tx_id, &secret_account, valid_asset_ids, account_id, rng)
+        .create(tx_id, &secret_account, valid_asset_ids, rng)
         .unwrap()
 }
 

--- a/src/mercat/account.rs
+++ b/src/mercat/account.rs
@@ -40,7 +40,6 @@ impl AccountCreatorInitializer for AccountCreator {
         tx_id: u32,
         scrt: &SecAccount,
         valid_asset_ids: &[Scalar],
-        account_id: u32,
         rng: &mut T,
     ) -> Fallible<PubAccountTx> {
         let balance_blinding = Scalar::random(rng);
@@ -89,7 +88,6 @@ impl AccountCreatorInitializer for AccountCreator {
 
         Ok(PubAccountTx {
             pub_account: PubAccount {
-                id: account_id,
                 enc_asset_id,
                 owner_enc_pub_key: scrt.enc_keys.pblc,
             },

--- a/src/mercat/account.rs
+++ b/src/mercat/account.rs
@@ -187,7 +187,6 @@ mod tests {
         let valid_asset_ids: Vec<AssetId> =
             vec![1, 2, 3].iter().map(|id| AssetId::from(*id)).collect();
         let valid_asset_ids = convert_asset_ids(valid_asset_ids);
-        let account_id = 2;
         let asset_id_witness = CommitmentWitness::from((asset_id.into(), &mut rng));
         let scrt_account = SecAccount {
             enc_keys,
@@ -199,7 +198,7 @@ mod tests {
         let tx_id = 0;
         let account_creator = AccountCreator {};
         let sndr_account_tx = account_creator
-            .create(tx_id, &scrt_account, &valid_asset_ids, account_id, &mut rng)
+            .create(tx_id, &scrt_account, &valid_asset_ids, &mut rng)
             .unwrap();
 
         let decrypted_balance = scrt_account
@@ -229,7 +228,6 @@ mod tests {
         let valid_asset_ids: Vec<AssetId> =
             vec![1, 2, 3].iter().map(|id| AssetId::from(*id)).collect();
         let valid_asset_ids = convert_asset_ids(valid_asset_ids);
-        let account_id = 2;
         let asset_id_witness = CommitmentWitness::from((asset_id.into(), &mut rng));
         let scrt_account = SecAccount {
             enc_keys,
@@ -241,7 +239,7 @@ mod tests {
         let tx_id = 0;
         let account_creator = AccountCreator {};
         let pub_account_tx = account_creator
-            .create(tx_id, &scrt_account, &valid_asset_ids, account_id, &mut rng)
+            .create(tx_id, &scrt_account, &valid_asset_ids, &mut rng)
             .unwrap();
 
         let balance = scrt_account

--- a/src/mercat/asset.rs
+++ b/src/mercat/asset.rs
@@ -381,13 +381,6 @@ mod tests {
             scrt: issuer_secret_account,
         };
 
-        // Generate keys for the mediator.
-        let mediator_elg_secret_key = ElgamalSecretKey::new(Scalar::random(&mut rng));
-        let mediator_enc_key = EncryptionKeys {
-            pblc: mediator_elg_secret_key.get_public_key(),
-            scrt: mediator_elg_secret_key,
-        };
-
         let mut seed = [0u8; 32];
         rng.fill_bytes(&mut seed);
 
@@ -420,8 +413,6 @@ mod tests {
 
     fn asset_issuance_auditing_helper(
         issuer_auditor_list: &[(u32, EncryptionPubKey)],
-        mediator_auditor_list: &[(u32, EncryptionPubKey)],
-        mediator_check_fails: bool,
         validator_auditor_list: &[(u32, EncryptionPubKey)],
         validator_check_fails: bool,
         auditors_list: &[(u32, EncryptionKeys)],
@@ -457,13 +448,6 @@ mod tests {
         let issuer_account = Account {
             pblc: issuer_public_account.clone(),
             scrt: issuer_secret_account,
-        };
-
-        // Generate keys for the mediator.
-        let mediator_elg_secret_key = ElgamalSecretKey::new(Scalar::random(&mut rng));
-        let mediator_enc_key = EncryptionKeys {
-            pblc: mediator_elg_secret_key.get_public_key(),
-            scrt: mediator_elg_secret_key,
         };
 
         let mut seed = [0u8; 32];
@@ -548,22 +532,11 @@ mod tests {
             auditors_list,
             auditors_list,
             false,
-            auditors_list,
-            false,
             auditors_secret_account_list,
         );
 
-        // Change the order of auditors lists on the mediator and validator sides.
+        // Change the order of auditors lists on validator side.
         // The tests still must pass.
-        let mediator_auditor_list = vec![
-            auditors_vec[1],
-            auditors_vec[0],
-            auditors_vec[3],
-            auditors_vec[2],
-            auditors_vec[4],
-        ];
-        let mediator_auditor_list = mediator_auditor_list.as_slice();
-
         let validator_auditor_list = vec![
             auditors_vec[4],
             auditors_vec[3],
@@ -575,15 +548,13 @@ mod tests {
 
         asset_issuance_auditing_helper(
             auditors_list,
-            mediator_auditor_list,
-            false,
             validator_auditor_list,
             false,
             auditors_secret_account_list,
         );
 
         // Asset doesn't have any auditors.
-        asset_issuance_auditing_helper(&[], &[], false, &[], false, &[]);
+        asset_issuance_auditing_helper(&[], &[], false, &[]);
 
         // Negative tests.
 
@@ -598,8 +569,6 @@ mod tests {
 
         asset_issuance_auditing_helper(
             &four_auditor_list,
-            mediator_auditor_list,
-            true,
             validator_auditor_list,
             true,
             auditors_secret_account_list,
@@ -608,8 +577,6 @@ mod tests {
         // Sender and mediator miss an auditor, but validator catches them.
         asset_issuance_auditing_helper(
             &four_auditor_list,
-            &four_auditor_list,
-            false,
             validator_auditor_list,
             true,
             auditors_secret_account_list,
@@ -618,8 +585,6 @@ mod tests {
         // Sender doesn't include any auditors. Mediator catches it.
         asset_issuance_auditing_helper(
             &[],
-            mediator_auditor_list,
-            true,
             validator_auditor_list,
             true,
             auditors_secret_account_list,
@@ -628,8 +593,6 @@ mod tests {
         // Sender and mediator don't believe in auditors but validator does.
         asset_issuance_auditing_helper(
             &[],
-            &[],
-            false,
             validator_auditor_list,
             true,
             auditors_secret_account_list,

--- a/src/mercat/asset.rs
+++ b/src/mercat/asset.rs
@@ -365,7 +365,6 @@ mod tests {
             asset_id_witness: CommitmentWitness::from((asset_id.into(), &mut rng)),
         };
 
-        let account_id = 1234u32;
         let valid_asset_ids: Vec<AssetId> =
             vec![1, 2, 3].iter().map(|id| AssetId::from(*id)).collect();
         let valid_asset_ids = convert_asset_ids(valid_asset_ids);
@@ -373,13 +372,7 @@ mod tests {
         let account_creator = AccountCreator {};
         let tx_id = 0;
         let issuer_account_tx = account_creator
-            .create(
-                tx_id,
-                &issuer_secret_account,
-                &valid_asset_ids,
-                account_id,
-                &mut rng,
-            )
+            .create(tx_id, &issuer_secret_account, &valid_asset_ids, &mut rng)
             .unwrap();
         let issuer_public_account = issuer_account_tx.pub_account;
         let issuer_init_balance = issuer_account_tx.initial_balance;
@@ -408,7 +401,13 @@ mod tests {
         // Positive test.
         let validator = AssetValidator {};
         let updated_issuer_balance = validator
-            .verify_asset_transaction(&asset_tx, &issuer_public_account, &issuer_init_balance, &[])
+            .verify_asset_transaction(
+                issued_amount,
+                &asset_tx,
+                &issuer_public_account,
+                &issuer_init_balance,
+                &[],
+            )
             .unwrap();
 
         // ----------------------- Processing
@@ -484,6 +483,7 @@ mod tests {
 
         let validator = AssetValidator {};
         let result = validator.verify_asset_transaction(
+            issued_amount,
             &asset_tx,
             &issuer_public_account,
             &issuer_init_balance,

--- a/src/mercat/asset.rs
+++ b/src/mercat/asset.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     errors::{ErrorKind, Fallible},
     mercat::{
-        Account, AssetMemo, AssetTransactionAuditor, AssetTransactionIssuer,
+        account::deposit, Account, AssetMemo, AssetTransactionAuditor, AssetTransactionIssuer,
         AssetTransactionVerifier, AuditorPayload, EncryptedAmount, EncryptionKeys,
         EncryptionPubKey, InitializedAssetTx, PubAccount,
     },
@@ -261,7 +261,7 @@ impl AssetTransactionVerifier for AssetValidator {
 
         // After successfully verifying the transaction, validator deposits the amount
         // to issuer's account (aka processing phase).
-        let updated_issr_balance = crate::mercat::account::deposit(
+        let updated_issr_balance = deposit(
             issr_init_balance,
             &initialized_asset_tx.memo.enc_issued_amount,
         );

--- a/src/mercat/mod.rs
+++ b/src/mercat/mod.rs
@@ -265,6 +265,7 @@ pub trait AssetTransactionVerifier {
     /// Called by validators to verify the justification and processing of the transaction.
     fn verify_asset_transaction(
         &self,
+        amount: u32,
         justified_asset_tx: &InitializedAssetTx,
         issr_account: &PubAccount,
         issr_init_balance: &EncryptedAmount,

--- a/src/mercat/mod.rs
+++ b/src/mercat/mod.rs
@@ -73,7 +73,7 @@ pub struct MediatorAccount {
 #[derive(Clone, Encode, Decode, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PubAccount {
-    pub id: u32,
+    // enc_asset_id acts as the account id.
     pub enc_asset_id: EncryptedAssetId,
     pub owner_enc_pub_key: EncryptionPubKey,
 }
@@ -115,7 +115,6 @@ pub trait AccountCreatorInitializer {
         tx_id: u32,
         scrt: &SecAccount,
         valid_asset_ids: &[Scalar],
-        account_id: u32,
         rng: &mut T,
     ) -> Fallible<PubAccountTx>;
 }
@@ -240,20 +239,11 @@ pub struct AssetMemo {
 #[derive(Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct InitializedAssetTx {
-    pub account_id: u32,
-    pub enc_asset_id: EncryptedAssetId,
-    pub enc_amount_for_mdtr: EncryptedAmountWithHint,
+    pub account_id: EncryptedAssetId,
     pub memo: AssetMemo,
-    pub asset_id_equal_cipher_proof: CipherEqualDifferentPubKeyProof,
     pub balance_wellformedness_proof: WellformednessProof,
     pub balance_correctness_proof: CorrectnessProof,
     pub auditors_payload: Vec<AuditorPayload>,
-}
-
-#[derive(Clone, Encode, Decode, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct JustifiedAssetTx {
-    pub init_data: InitializedAssetTx,
 }
 
 /// The interface for the confidential asset issuance transaction.
@@ -265,34 +255,19 @@ pub trait AssetTransactionIssuer {
         &self,
         tx_id: u32,
         issr_account: &Account,
-        mdtr_pub_key: &EncryptionPubKey,
         auditors_enc_pub_keys: &[(u32, EncryptionPubKey)],
         amount: Balance,
         rng: &mut T,
     ) -> Fallible<InitializedAssetTx>;
 }
 
-pub trait AssetTransactionMediator {
-    /// Justifies and processes a confidential asset issue transaction. This includes checking
-    /// the transaction for proper auditors payload. This method is called
-    /// by mediator. Corresponds to `JustifyAssetTx` of MERCAT paper.
-    fn justify_asset_transaction(
-        &self,
-        initialized_asset_tx: InitializedAssetTx,
-        issr_pub_account: &PubAccount,
-        mdtr_enc_keys: &EncryptionKeys,
-        auditors_enc_pub_keys: &[(u32, EncryptionPubKey)],
-    ) -> Fallible<JustifiedAssetTx>;
-}
-
 pub trait AssetTransactionVerifier {
     /// Called by validators to verify the justification and processing of the transaction.
     fn verify_asset_transaction(
         &self,
-        justified_asset_tx: &JustifiedAssetTx,
+        justified_asset_tx: &InitializedAssetTx,
         issr_account: &PubAccount,
         issr_init_balance: &EncryptedAmount,
-        mdtr_enc_pub_key: &EncryptionPubKey,
         auditors_enc_pub_keys: &[(u32, EncryptionPubKey)],
     ) -> Fallible<EncryptedAmount>;
 }
@@ -302,9 +277,8 @@ pub trait AssetTransactionAuditor {
     /// Audit the sender's encrypted amount.
     fn audit_asset_transaction(
         &self,
-        justified_asset_tx: &JustifiedAssetTx,
+        justified_asset_tx: &InitializedAssetTx,
         issuer_account: &PubAccount,
-        mdtr_enc_pub_key: &EncryptionPubKey,
         auditor_enc_keys: &(u32, EncryptionKeys),
     ) -> Fallible<()>;
 }
@@ -325,8 +299,8 @@ pub struct AuditorPayload {
 #[derive(Default, Clone, Copy, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TransferTxMemo {
-    pub sndr_account_id: u32,
-    pub rcvr_account_id: u32,
+    pub sndr_account_id: EncryptedAssetId,
+    pub rcvr_account_id: EncryptedAssetId,
     pub enc_amount_using_sndr: EncryptedAmount,
     pub enc_amount_using_rcvr: EncryptedAmount,
     pub refreshed_enc_balance: EncryptedAmount,

--- a/src/mercat/mod.rs
+++ b/src/mercat/mod.rs
@@ -227,7 +227,7 @@ impl core::fmt::Debug for TransferTxState {
 // -------------------------------------------------------------------------------------
 
 /// Asset memo holds the contents of an asset issuance transaction.
-#[derive(Clone, Encode, Decode, Debug)]
+#[derive(Clone, Encode, Decode, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AssetMemo {
     pub enc_issued_amount: EncryptedAmount,
@@ -236,7 +236,7 @@ pub struct AssetMemo {
 
 /// Holds the public portion of an asset issuance transaction after initialization.
 /// This can be placed on the chain.
-#[derive(Clone, Encode, Decode, Debug)]
+#[derive(Clone, Encode, Decode, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct InitializedAssetTx {
     pub account_id: EncryptedAssetId,
@@ -287,7 +287,7 @@ pub trait AssetTransactionAuditor {
 // -                       Confidential Transfer Transaction                           -
 // -------------------------------------------------------------------------------------
 
-#[derive(Clone, Encode, Decode, Debug)]
+#[derive(Clone, Encode, Decode, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AuditorPayload {
     pub auditor_id: u32,

--- a/src/mercat/transaction.rs
+++ b/src/mercat/transaction.rs
@@ -186,8 +186,8 @@ impl TransferTransactionSender for CtxSender {
             asset_id_correctness_proof,
             amount_correctness_proof,
             memo: TransferTxMemo {
-                sndr_account_id: sndr_pub_account.id,
-                rcvr_account_id: rcvr_pub_account.id,
+                sndr_account_id: sndr_pub_account.enc_asset_id,
+                rcvr_account_id: rcvr_pub_account.enc_asset_id,
                 enc_amount_using_sndr: sndr_new_enc_amount,
                 enc_amount_using_rcvr: rcvr_new_enc_amount,
                 refreshed_enc_balance,
@@ -393,7 +393,7 @@ impl TransferTransactionVerifier for TransactionValidator {
         rng: &mut R,
     ) -> Fallible<(EncryptedAmount, EncryptedAmount)> {
         ensure!(
-            sndr_account.id
+            sndr_account.enc_asset_id
                 == justified_transaction
                     .finalized_data
                     .init_data
@@ -402,7 +402,7 @@ impl TransferTransactionVerifier for TransactionValidator {
             ErrorKind::AccountIdMismatch
         );
         ensure!(
-            rcvr_account.id
+            rcvr_account.enc_asset_id
                 == justified_transaction
                     .finalized_data
                     .init_data
@@ -620,7 +620,7 @@ impl TransferTransactionAuditor for CtxAuditor {
         auditor_enc_key: &(u32, EncryptionKeys),
     ) -> Fallible<()> {
         ensure!(
-            sndr_account.id
+            sndr_account.enc_asset_id
                 == justified_transaction
                     .finalized_data
                     .init_data
@@ -629,7 +629,7 @@ impl TransferTransactionAuditor for CtxAuditor {
             ErrorKind::AccountIdMismatch
         );
         ensure!(
-            rcvr_account.id
+            rcvr_account.enc_asset_id
                 == justified_transaction
                     .finalized_data
                     .init_data
@@ -722,8 +722,8 @@ mod tests {
         let (_, enc_amount_using_rcvr) = rcvr_pub_key.encrypt_value(amount.into(), rng);
         let (_, enc_asset_id_using_rcvr) = rcvr_pub_key.encrypt_value(asset_id.into(), rng);
         TransferTxMemo {
-            sndr_account_id: 0,
-            rcvr_account_id: 0,
+            sndr_account_id: EncryptedAssetId::default(),
+            rcvr_account_id: EncryptedAssetId::default(),
             enc_amount_using_sndr: EncryptedAmount::default(),
             enc_amount_using_rcvr,
             refreshed_enc_balance: EncryptedAmount::default(),
@@ -746,7 +746,6 @@ mod tests {
 
         Ok((
             PubAccount {
-                id: 1,
                 enc_asset_id,
                 owner_enc_pub_key: rcvr_enc_pub_key,
             },


### PR DESCRIPTION
CRYP-160

Since minting assets does not require mediators, the mercat lib is changed.

**NOTE:** previously, the issued amount was encrypted to the mediator's public key and then the mediator could verify that the encrypted amount is correct. Now, with the absence of mediator and the fact that the polymesh functions receive the total supply plainly, I am passing the amount as a plain value to the verification function.