### PR TITLE
Replace OS RNG with ChaCha20 RNG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ blake2 = { version = "0.9.0", default-features = false }
 
 rand_core = { version = "0.5", default-features = false}
 rand = { version = "0.7", default-features = false }
+rand_chacha = {version = "0.2.1", default-features = false }
 getrandom = { version = "0.1.14", default-features = false, optional = true}
 
 curve25519-dalek = { version = "2", default-features = false, features = ["nightly"] }


### PR DESCRIPTION
Addresses CRYP-171. The gist of it is that WASM does not support OS RNGs, so we have to use our own; but ChaCha20 with an all zeros seed is not the wisest choice.