### PR TITLE
Include set size in the membership proofs

### DIFF
--- a/benches/mercat_transaction.rs
+++ b/benches/mercat_transaction.rs
@@ -32,7 +32,7 @@ fn bench_transaction_sender(
     sender_account: Account,
     sender_balances: Vec<EncryptedAmount>,
     rcvr_pub_account: PubAccount,
-    mdtr_pub_key: EncryptionPubKey,
+    mediator_pub_key: EncryptionPubKey,
 ) -> Vec<InitializedTransferTx> {
     let label = "MERCAT Transaction: Sender".to_string();
     let mut rng = thread_rng();
@@ -56,7 +56,7 @@ fn bench_transaction_sender(
                         &sender_account_cloned,
                         sender_balance,
                         &rcvr_pub_account_cloned,
-                        &mdtr_pub_key.clone(),
+                        &mediator_pub_key.clone(),
                         &[],
                         *amount,
                         &mut rng,
@@ -76,7 +76,7 @@ fn bench_transaction_sender(
                     &sender_account.clone(),
                     sender_balance,
                     &rcvr_pub_account,
-                    &mdtr_pub_key.clone(),
+                    &mediator_pub_key.clone(),
                     &[],
                     *amount,
                     &mut rng,

--- a/src/asset_proofs/membership_proof.rs
+++ b/src/asset_proofs/membership_proof.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 
 use codec::{Decode, Encode, Error as CodecError, Input, Output};
-use sp_std::{mem, cmp::min, convert::TryFrom, prelude::*};
+use sp_std::{cmp::min, convert::TryFrom, mem, prelude::*};
 
 pub const MEMBERSHIP_PROOF_LABEL: &[u8] = b"PolymathMembershipProofLabel";
 const MEMBERSHIP_PROOF_CHALLENGE_LABEL: &[u8] = b"PolymathMembershipProofChallengeLabel";
@@ -67,7 +67,7 @@ impl Decode for MembershipProofInitialMessage {
         Ok(MembershipProofInitialMessage {
             ooon_proof_initial_message,
             secret_element_comm,
-            elements_set_size
+            elements_set_size,
         })
     }
 }

--- a/src/asset_proofs/membership_proof.rs
+++ b/src/asset_proofs/membership_proof.rs
@@ -289,7 +289,13 @@ impl<'a> AssetProofVerifier for MembershipProofVerifier<'a> {
         let exp = u32::try_from(m).map_err(|_| ErrorKind::InvalidExponentParameter)?;
         let size = initial_message.ooon_proof_initial_message.n.pow(exp) as usize;
 
-        let element_set_size = initial_message.elements_set_size as usize;
+        // Use the minimum of the prover and verifier's elements set size.
+        // This way if on the verifier side, new elements are appended to the elements
+        // set, the proofs made with the old element set will still verify.
+        let element_set_size = min(
+            initial_message.elements_set_size as usize,
+            self.elements_set.len(),
+        );
 
         let initial_size = min(element_set_size, size);
         ensure!(initial_size != 0, ErrorKind::EmptyElementsSet);

--- a/src/mercat/mod.rs
+++ b/src/mercat/mod.rs
@@ -304,8 +304,8 @@ pub struct TransferTxMemo {
     pub refreshed_enc_balance: EncryptedAmount,
     pub refreshed_enc_asset_id: EncryptedAssetId,
     pub enc_asset_id_using_receiver: EncryptedAssetId,
-    pub enc_asset_id_for_mdtr: EncryptedAssetId,
-    pub enc_amount_for_mdtr: EncryptedAmountWithHint,
+    pub enc_asset_id_for_mediator: EncryptedAssetId,
+    pub enc_amount_for_mediator: EncryptedAmountWithHint,
 }
 
 /// Holds the proofs and memo of the confidential transaction sent by the sender.
@@ -349,7 +349,7 @@ pub trait TransferTransactionSender {
         sender_account: &Account,
         sender_init_balance: &EncryptedAmount,
         receiver_pub_account: &PubAccount,
-        mdtr_pub_key: &EncryptionPubKey,
+        mediator_pub_key: &EncryptionPubKey,
         auditors_enc_pub_keys: &[(u32, EncryptionPubKey)],
         amount: Balance,
         rng: &mut T,
@@ -374,7 +374,7 @@ pub trait TransferTransactionMediator {
     fn justify_transaction<R: RngCore + CryptoRng>(
         &self,
         finalized_transaction: FinalizedTransferTx,
-        mdtr_enc_keys: &EncryptionKeys,
+        mediator_enc_keys: &EncryptionKeys,
         sender_account: &PubAccount,
         sender_init_balance: &EncryptedAmount,
         receiver_account: &PubAccount,
@@ -432,7 +432,7 @@ pub trait ReversedTransferTransactionMediator {
     fn create(
         &self,
         transaction_final_data: FinalizedTransferTx,
-        mdtr_enc_keys: EncryptionSecKey,
+        mediator_enc_keys: EncryptionSecKey,
         state: TransferTxState,
     ) -> Fallible<(ReversedTransferTx, TransferTxState)>;
 }

--- a/src/mercat/mod.rs
+++ b/src/mercat/mod.rs
@@ -386,7 +386,6 @@ pub trait TransferTransactionMediator {
 
 pub trait TransferTransactionVerifier {
     /// Verify the initialized, finalized, and justified transactions.
-    /// Returns the updated sender and receiver accounts.
     fn verify_transaction<R: RngCore + CryptoRng>(
         &self,
         justified_transaction: &JustifiedTransferTx,

--- a/src/mercat/transaction.rs
+++ b/src/mercat/transaction.rs
@@ -151,7 +151,8 @@ impl TransferTransactionSender for CtxSender {
         let amount_witness_blinding_for_mediator = Scalar::random(rng);
         let amount_witness_for_mediator =
             CommitmentWitness::new(amount.into(), amount_witness_blinding_for_mediator);
-        let enc_amount_for_mediator = mediator_pub_key.const_time_encrypt(&amount_witness_for_mediator, rng);
+        let enc_amount_for_mediator =
+            mediator_pub_key.const_time_encrypt(&amount_witness_for_mediator, rng);
 
         let asset_id_correctness_proof = single_property_prover(
             CorrectnessProverAwaitingChallenge {

--- a/src/mercat/transaction.rs
+++ b/src/mercat/transaction.rs
@@ -45,7 +45,7 @@ impl TransferTransactionSender for CtxSender {
         sender_account: &Account,
         sender_init_balance: &EncryptedAmount,
         receiver_pub_account: &PubAccount,
-        mdtr_pub_key: &EncryptionPubKey,
+        mediator_pub_key: &EncryptionPubKey,
         auditors_enc_pub_keys: &[(u32, EncryptionPubKey)],
         amount: Balance,
         rng: &mut T,
@@ -143,15 +143,15 @@ impl TransferTransactionSender for CtxSender {
         )?;
 
         // Prepare the correctness proofs for the mediator.
-        let asset_id_witness_blinding_for_mdtr = Scalar::random(rng);
-        let asset_id_witness_for_mdtr =
-            CommitmentWitness::new(asset_id, asset_id_witness_blinding_for_mdtr);
-        let enc_asset_id_for_mdtr = mdtr_pub_key.encrypt(&asset_id_witness_for_mdtr);
+        let asset_id_witness_blinding_for_mediator = Scalar::random(rng);
+        let asset_id_witness_for_mediator =
+            CommitmentWitness::new(asset_id, asset_id_witness_blinding_for_mediator);
+        let enc_asset_id_for_mediator = mediator_pub_key.encrypt(&asset_id_witness_for_mediator);
 
-        let amount_witness_blinding_for_mdtr = Scalar::random(rng);
-        let amount_witness_for_mdtr =
-            CommitmentWitness::new(amount.into(), amount_witness_blinding_for_mdtr);
-        let enc_amount_for_mdtr = mdtr_pub_key.const_time_encrypt(&amount_witness_for_mdtr, rng);
+        let amount_witness_blinding_for_mediator = Scalar::random(rng);
+        let amount_witness_for_mediator =
+            CommitmentWitness::new(amount.into(), amount_witness_blinding_for_mediator);
+        let enc_amount_for_mediator = mediator_pub_key.const_time_encrypt(&amount_witness_for_mediator, rng);
 
         let asset_id_correctness_proof = single_property_prover(
             CorrectnessProverAwaitingChallenge {
@@ -196,8 +196,8 @@ impl TransferTransactionSender for CtxSender {
                 refreshed_enc_balance,
                 refreshed_enc_asset_id,
                 enc_asset_id_using_receiver,
-                enc_asset_id_for_mdtr,
-                enc_amount_for_mdtr,
+                enc_asset_id_for_mediator,
+                enc_amount_for_mediator,
             },
             auditors_payload,
         })
@@ -306,7 +306,7 @@ impl TransferTransactionMediator for CtxMediator {
     fn justify_transaction<R: RngCore + CryptoRng>(
         &self,
         finalized_transaction: FinalizedTransferTx,
-        mdtr_enc_keys: &EncryptionKeys,
+        mediator_enc_keys: &EncryptionKeys,
         sender_account: &PubAccount,
         sender_init_balance: &EncryptedAmount,
         receiver_account: &PubAccount,
@@ -333,9 +333,9 @@ impl TransferTransactionMediator for CtxMediator {
         let tx_data = &init_tx_data;
 
         // Verify that the encrypted amount is correct.
-        let amount = mdtr_enc_keys
+        let amount = mediator_enc_keys
             .secret
-            .const_time_decrypt(&tx_data.memo.enc_amount_for_mdtr)?;
+            .const_time_decrypt(&tx_data.memo.enc_amount_for_mediator)?;
         single_property_verifier(
             &CorrectnessVerifier {
                 value: amount.into(),
@@ -347,8 +347,8 @@ impl TransferTransactionMediator for CtxMediator {
         )?;
 
         // Verify that the encrypted asset_id is correct.
-        mdtr_enc_keys.secret.verify(
-            &tx_data.memo.enc_asset_id_for_mdtr,
+        mediator_enc_keys.secret.verify(
+            &tx_data.memo.enc_asset_id_for_mediator,
             &asset_id_hint.clone().into(),
         )?;
 
@@ -714,8 +714,8 @@ mod tests {
             refreshed_enc_balance: EncryptedAmount::default(),
             refreshed_enc_asset_id: EncryptedAssetId::default(),
             enc_asset_id_using_receiver,
-            enc_asset_id_for_mdtr: EncryptedAssetId::default(),
-            enc_amount_for_mdtr: EncryptedAmountWithHint::default(),
+            enc_asset_id_for_mediator: EncryptedAssetId::default(),
+            enc_amount_for_mediator: EncryptedAmountWithHint::default(),
         }
     }
 
@@ -856,7 +856,7 @@ mod tests {
     fn test_ctx_create_finalize_validate_success() {
         let sender = CtxSender;
         let receiver = CtxReceiver;
-        let mdtr = CtxMediator;
+        let mediator = CtxMediator;
         let tx_validator = TransactionValidator;
         let asset_id = AssetId::from(20);
         let sender_balance = 40;
@@ -869,7 +869,7 @@ mod tests {
 
         let receiver_enc_keys = mock_gen_enc_key_pair(12u8);
 
-        let mdtr_enc_keys = mock_gen_enc_key_pair(14u8);
+        let mediator_enc_keys = mock_gen_enc_key_pair(14u8);
 
         let (receiver_pub_account, receiver_init_balance) = mock_gen_account(
             receiver_enc_keys.public,
@@ -906,7 +906,7 @@ mod tests {
             &sender_account,
             &sender_init_balance,
             &receiver_account.public,
-            &mdtr_enc_keys.public,
+            &mediator_enc_keys.public,
             &[],
             amount,
             &mut rng,
@@ -923,9 +923,9 @@ mod tests {
         let ctx_finalized_data = result.unwrap();
 
         // Justify the transaction
-        let result = mdtr.justify_transaction(
+        let result = mediator.justify_transaction(
             ctx_finalized_data,
-            &mdtr_enc_keys,
+            &mediator_enc_keys,
             &sender_account.public,
             &sender_init_balance,
             &receiver_account.public,
@@ -1015,7 +1015,7 @@ mod tests {
     ) {
         let sender = CtxSender;
         let receiver = CtxReceiver;
-        let mdtr = CtxMediator;
+        let mediator = CtxMediator;
         let validator = TransactionValidator;
         let asset_id = AssetId::from(20);
         let sender_balance = 500;
@@ -1024,7 +1024,7 @@ mod tests {
 
         let mut rng = StdRng::from_seed([19u8; 32]);
 
-        let mdtr_enc_keys = mock_gen_enc_key_pair(140u8);
+        let mediator_enc_keys = mock_gen_enc_key_pair(140u8);
 
         let (receiver_account, receiver_init_balance) =
             account_create_helper([18u8; 32], 120u8, receiver_balance, asset_id.clone());
@@ -1038,7 +1038,7 @@ mod tests {
                 &sender_account,
                 &sender_init_balance,
                 &receiver_account.public,
-                &mdtr_enc_keys.public,
+                &mediator_enc_keys.public,
                 sender_auditor_list,
                 amount,
                 &mut rng,
@@ -1051,9 +1051,9 @@ mod tests {
             .unwrap();
 
         // Justify the transaction
-        let result = mdtr.justify_transaction(
+        let result = mediator.justify_transaction(
             ctx_final,
-            &mdtr_enc_keys,
+            &mediator_enc_keys,
             &sender_account.public,
             &sender_init_balance,
             &receiver_account.public,


### PR DESCRIPTION
Addresses CRYP-163. Just to be on the safe side, with this change, we will add the elements' set size to the membership proofs. This change doesn't touch the mercat API, so the integration with Polymesh should be seamless. 