### PR TITLE
change dependencies to used a fixed version of dalek v2 that uses packed_simd_2

### DIFF
--- a/cli/cil/common/Cargo.toml
+++ b/cli/cil/common/Cargo.toml
@@ -15,5 +15,5 @@ serde_bytes = { version = "0.11", default-features = false, features = ["alloc"]
 
 # Crypto
 rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
-curve25519-dalek = { version = "2.0.0", features = ["u64_backend", "alloc", "serde"], default-features = false }
+curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend"] }
 blake2 = { version = "0.9.0", default-features = false }

--- a/cli/cil/scp/Cargo.toml
+++ b/cli/cil/scp/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 # Crypto
 rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
 rand_core = { version = "0.5", default-features = false}
-curve25519-dalek = { version = "2", default-features = false, features = ["nightly"] }
+curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend"] }
 
 # Only binaries
 structopt = { version = "0.3", default-features = false }

--- a/cli/cil/scv/Cargo.toml
+++ b/cli/cil/scv/Cargo.toml
@@ -14,7 +14,9 @@ serde = { version = "1.0.105", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 # Crypto
-schnorrkel = { version = "0.9.1", features = ["u64_backend", "wasm-bindgen"], default-features = false }
+# schnorrkel = { version = "0.9.1", features = ["u64_backend", "wasm-bindgen"], default-features = false }
+schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false, features = ["u64_backend", "wasm-bindgen"]}
+curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend"] }
 
 # Only binaries
 structopt = { version = "0.3", default-features = false }

--- a/cli/mercat/chain_setup/Cargo.toml
+++ b/cli/mercat/chain_setup/Cargo.toml
@@ -24,5 +24,6 @@ failure = { version = "0.1.7" }
 
 # Crypto
 rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
-curve25519-dalek = { version = "2.0.0", features = ["u64_backend", "alloc", "serde"], default-features = false }
-schnorrkel = { version = "0.9.1", default-features = false }
+# curve25519-dalek = { version = "2.0.0", features = ["u64_backend", "alloc", "serde"], default-features = false }
+curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend", "alloc", "serde"] }
+schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false }

--- a/cli/mercat/chain_setup/Cargo.toml
+++ b/cli/mercat/chain_setup/Cargo.toml
@@ -24,6 +24,5 @@ failure = { version = "0.1.7" }
 
 # Crypto
 rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
-# curve25519-dalek = { version = "2.0.0", features = ["u64_backend", "alloc", "serde"], default-features = false }
 curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend", "alloc", "serde"] }
 schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false }

--- a/cli/mercat/common/Cargo.toml
+++ b/cli/mercat/common/Cargo.toml
@@ -26,7 +26,8 @@ hex = { version = "0.4.2" }
 
 # Crypto
 rand = { version = "0.7.3", features = ["getrandom", "alloc"] }
-curve25519-dalek = { version = "2.0.0", features = ["u64_backend", "alloc", "serde"] }
+# curve25519-dalek = { version = "2.0.0", features = ["u64_backend", "alloc", "serde"] }
+curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend", "alloc", "serde"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.10"

--- a/cli/mercat/common/Cargo.toml
+++ b/cli/mercat/common/Cargo.toml
@@ -26,7 +26,6 @@ hex = { version = "0.4.2" }
 
 # Crypto
 rand = { version = "0.7.3", features = ["getrandom", "alloc"] }
-# curve25519-dalek = { version = "2.0.0", features = ["u64_backend", "alloc", "serde"] }
 curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend", "alloc", "serde"] }
 
 [dev-dependencies]

--- a/cli/mercat/interactive/Cargo.toml
+++ b/cli/mercat/interactive/Cargo.toml
@@ -26,4 +26,5 @@ failure = { version = "0.1.7" }
 # Crypto
 rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
 hex = { version = "0.4.2" }
-curve25519-dalek = { version = "2.0.0", features = ["u64_backend", "alloc", "serde"] }
+# curve25519-dalek = { version = "2.0.0", features = ["u64_backend", "alloc", "serde"] }
+curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend", "alloc", "serde"] }

--- a/cli/mercat/interactive/Cargo.toml
+++ b/cli/mercat/interactive/Cargo.toml
@@ -26,5 +26,4 @@ failure = { version = "0.1.7" }
 # Crypto
 rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
 hex = { version = "0.4.2" }
-# curve25519-dalek = { version = "2.0.0", features = ["u64_backend", "alloc", "serde"] }
 curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend", "alloc", "serde"] }

--- a/cli/mercat/mediator/Cargo.toml
+++ b/cli/mercat/mediator/Cargo.toml
@@ -24,8 +24,8 @@ base64 = { version = "0.12.1" }
 failure = { version = "0.1.7" }
 
 # Crypto
-curve25519-dalek = { version = "2", default-features = false }
-schnorrkel = { version = "0.9.1", default-features = false }
+curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend"] }
+schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false }
 rand_core = { version = "0.5", default-features = false }
 rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
 

--- a/cli/mercat/validator/Cargo.toml
+++ b/cli/mercat/validator/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.105", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 # Crypto
-curve25519-dalek = { version = "2", default-features = false }
-schnorrkel = { version = "0.9.1", default-features = false }
+curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend"] }
+schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false }
 rand_core = { version = "0.5", default-features = false }
 rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -32,17 +32,21 @@ rand_core = { version = "0.5", default-features = false}
 rand = { version = "0.7", default-features = false }
 getrandom = { version = "0.1.14", default-features = false, optional = true}
 
-curve25519-dalek = { version = "2", default-features = false, features = ["nightly"] }
-schnorrkel = { version = "0.9.1", default-features = false }
+# curve25519-dalek = { version = "2", default-features = false, features = ["nightly"] }
+# schnorrkel = { version = "0.9.1", default-features = false }
+# bulletproofs = { git = "https://github.com/PolymathNetwork/bulletproofs.git", branch = "main", default-features = false, features = ["zeroize"] }
+
+curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend"] }
+schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false }
+bulletproofs = { git = "https://github.com/PolymathNetwork/bulletproofs.git", branch = "v2-packed-simd", default-features = false, features = ["zeroize"] }
+
 merlin = { version = "2.0.0", default-features = false }
-bulletproofs = { git = "https://github.com/PolymathNetwork/bulletproofs.git", branch = "main", default-features = false, features = ["zeroize"] }
 
 [dev-dependencies]
 wasm-bindgen-test = { version = "0.3.10"}
 
 [features]
-# default = ["std", "avx2_backend"]
-default = ["std", "u64_backend"]
+default = ["std", "avx2_backend"]
 
 # Backends
 u32_backend = [

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -32,10 +32,6 @@ rand_core = { version = "0.5", default-features = false}
 rand = { version = "0.7", default-features = false }
 getrandom = { version = "0.1.14", default-features = false, optional = true}
 
-# curve25519-dalek = { version = "2", default-features = false, features = ["nightly"] }
-# schnorrkel = { version = "0.9.1", default-features = false }
-# bulletproofs = { git = "https://github.com/PolymathNetwork/bulletproofs.git", branch = "main", default-features = false, features = ["zeroize"] }
-
 curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend"] }
 schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false }
 bulletproofs = { git = "https://github.com/PolymathNetwork/bulletproofs.git", branch = "v2-packed-simd", default-features = false, features = ["zeroize"] }

--- a/cryptography/src/asset_proofs/ciphertext_refreshment_proof.rs
+++ b/cryptography/src/asset_proofs/ciphertext_refreshment_proof.rs
@@ -268,7 +268,6 @@ mod tests {
     use super::*;
     use crate::asset_proofs::*;
     use rand::{rngs::StdRng, SeedableRng};
-    use sp_std::prelude::*;
     use wasm_bindgen_test::*;
 
     const SEED_1: [u8; 32] = [17u8; 32];

--- a/cryptography/src/asset_proofs/range_proof.rs
+++ b/cryptography/src/asset_proofs/range_proof.rs
@@ -144,7 +144,6 @@ mod tests {
     use super::*;
     use crate::asset_proofs::*;
     use rand::{rngs::StdRng, SeedableRng};
-    use sp_std::prelude::*;
     use wasm_bindgen_test::*;
 
     const SEED_1: [u8; 32] = [42u8; 32];

--- a/cryptography/src/claim_proofs/ffi_wrapper/Cargo.toml
+++ b/cryptography/src/claim_proofs/ffi_wrapper/Cargo.toml
@@ -18,8 +18,8 @@ path = "../../.."
 
 [dependencies]
 libc = "^0.2"
-curve25519-dalek = { version = "2", default-features = false, features = ["nightly"] }
-schnorrkel = { version = "0.9.1", default-features = false }
+curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend"] }
+schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false }
 
 [build-dependencies]
 cbindgen = { version = "^0.13", optional = true }


### PR DESCRIPTION
The branch on our local fork of dalek with the fix: https://github.com/PolymathNetwork/curve25519-dalek/tree/v2-packed-simd

Schnorkel and bulletproof also depend on dalek. They are also forked and changed to use the above fixed version of dalek.

https://github.com/PolymathNetwork/schnorrkel/tree/fix-simd-issue
https://github.com/PolymathNetwork/bulletproofs/tree/v2-packed-simd

I will also explore the use of `[patch]` as suggested in https://github.com/w3f/schnorrkel/pull/62#issuecomment-723364047
