### PR TITLE
Wasm builder CRYP-184

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 members = [
 	"cryptography",
-    "wasm_builder",
+	"wasm_builder",
 	"cli/cil/common",
 	"cli/cil/scp",
 	"cli/cil/scv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
 	"cryptography",
+    "wasm_builder",
 	"cli/cil/common",
 	"cli/cil/scp",
 	"cli/cil/scv",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -41,6 +41,9 @@ merlin = { version = "2.0.0", default-features = false }
 [dev-dependencies]
 wasm-bindgen-test = { version = "0.3.10"}
 
+# [build-dependencies]
+# wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0"}
+
 [features]
 default = ["std", "avx2_backend"]
 

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -41,9 +41,6 @@ merlin = { version = "2.0.0", default-features = false }
 [dev-dependencies]
 wasm-bindgen-test = { version = "0.3.10"}
 
-# [build-dependencies]
-# wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0"}
-
 [features]
 default = ["std", "avx2_backend"]
 

--- a/wasm_builder/Cargo.toml
+++ b/wasm_builder/Cargo.toml
@@ -11,4 +11,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 cryptography = { path = "../cryptography/" }
+rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
+rand_core = { version = "0.5", default-features = false}
+curve25519-dalek = { version = "2", default-features = false, features = ["nightly"] }
+serde = { version = "1.0.105", features = ["derive"] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 wasm-bindgen = "0.2"

--- a/wasm_builder/Cargo.toml
+++ b/wasm_builder/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wasm-builder"
+version = "0.1.0"
+authors = ["Polymath Inc"]
+description = "A sample project with wasm-pack"
+repository = "https://github.com/PolymathNetwork/cryptography"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"

--- a/wasm_builder/Cargo.toml
+++ b/wasm_builder/Cargo.toml
@@ -14,6 +14,8 @@ cryptography = { path = "../cryptography/" }
 rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
 rand_core = { version = "0.5", default-features = false}
 curve25519-dalek = { version = "2", default-features = false, features = ["nightly"] }
+blake2 = { version = "0.9.0", default-features = false }
 serde = { version = "1.0.105", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+serde_bytes = { version = "0.11", default-features = false, features = ["alloc"]}
 wasm-bindgen = "0.2"

--- a/wasm_builder/Cargo.toml
+++ b/wasm_builder/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 cryptography = { path = "../cryptography/" }
 rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
 rand_core = { version = "0.5", default-features = false}
-curve25519-dalek = { version = "2", default-features = false, features = ["nightly"] }
+curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend"] }
 blake2 = { version = "0.9.0", default-features = false }
 serde = { version = "1.0.105", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/wasm_builder/Cargo.toml
+++ b/wasm_builder/Cargo.toml
@@ -9,4 +9,5 @@ repository = "https://github.com/PolymathNetwork/cryptography"
 crate-type = ["cdylib"]
 
 [dependencies]
+cryptography = { path = "../cryptography/" }
 wasm-bindgen = "0.2"

--- a/wasm_builder/Cargo.toml
+++ b/wasm_builder/Cargo.toml
@@ -19,3 +19,6 @@ serde = { version = "1.0.105", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_bytes = { version = "0.11", default-features = false, features = ["alloc"]}
 wasm-bindgen = "0.2"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-mutable-globals"]

--- a/wasm_builder/Cargo.toml
+++ b/wasm_builder/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Polymath Inc"]
 description = "A sample project with wasm-pack"
 repository = "https://github.com/PolymathNetwork/cryptography"
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/wasm_builder/src/lib.rs
+++ b/wasm_builder/src/lib.rs
@@ -1,0 +1,11 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    pub fn alert(s: &str);
+}
+
+#[wasm_bindgen]
+pub fn greet(name: &str) {
+    alert(&format!("Hello, {}!", name));
+}

--- a/wasm_builder/src/lib.rs
+++ b/wasm_builder/src/lib.rs
@@ -1,9 +1,16 @@
-use cryptography::claim_proofs::{compute_cdd_id, CddClaimData};
+use blake2::{Blake2s, Digest};
+use cryptography::claim_proofs::{
+    build_scope_claim_proof_data, compute_cdd_id, compute_scope_id, CddClaimData, ProofKeyPair,
+    ScopeClaimData,
+};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 type InvestorDID = [u8; 32];
+
+// Ticker, a 12 bytes slice, is the scope DID.
+pub type ScopeDID = [u8; 12];
 
 // Unique ID is a UUIDv4.
 type UniqueID = [u8; 16];
@@ -17,6 +24,31 @@ pub struct CddId {
 pub struct RawCddClaimData {
     pub investor_did: InvestorDID,
     pub investor_unique_id: UniqueID,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RawScopeClaimData {
+    pub scope_did: ScopeDID,
+    pub investor_unique_id: UniqueID,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Proof {
+    pub cdd_id: RistrettoPoint,
+    pub investor_did: InvestorDID,
+    pub scope_id: RistrettoPoint,
+    pub scope_did: ScopeDID,
+    #[serde(with = "serde_bytes")]
+    pub proof: Vec<u8>,
+}
+
+/// Returns the message used for checking the proof.
+pub fn make_message(investor_did: &InvestorDID, scope_did: &ScopeDID) -> [u8; 32] {
+    Blake2s::default()
+        .chain(investor_did)
+        .chain(scope_did)
+        .finalize()
+        .into()
 }
 
 /// Creates a CDD_ID from investor did and investor uid
@@ -41,4 +73,54 @@ pub fn process_create_cdd_id(cdd_claim: String) -> String {
         .unwrap_or_else(|error| panic!("Failed to serialize the CDD Id: {}", error));
 
     cdd_id_str
+}
+
+/// Creates a scope claim proof for an investor from investor did, investor uid, and scope did.
+///
+/// # Arguments
+/// * `cdd_claim` a stringified json with the following format:
+///   { "investor_did": [32_bytes_array], "investor_unique_id": [16_bytes_array] }
+/// * `scoped_claim` a stringified json with the following format:
+///   { "scope_did":[12_bytes_array], "investor_unique_id":[16_bytes_array] }
+///
+/// # Errors
+/// * `TODO` panicing at the moment.
+#[wasm_bindgen]
+pub fn process_create_claim_proof(cdd_claim: String, scoped_claim: String) -> String {
+    let raw_cdd_claim: RawCddClaimData = serde_json::from_str(&cdd_claim)
+        .unwrap_or_else(|error| panic!("Failed to deserialize the cdd claim: {}", error));
+
+    let raw_scope_claim: RawScopeClaimData = serde_json::from_str(&scoped_claim)
+        .unwrap_or_else(|error| panic!("Failed to deserialize the scope claim: {}", error));
+
+    let message = make_message(&raw_cdd_claim.investor_did, &raw_scope_claim.scope_did);
+
+    let cdd_claim = CddClaimData::new(
+        &raw_cdd_claim.investor_did,
+        &raw_cdd_claim.investor_unique_id,
+    );
+    let scope_claim = ScopeClaimData::new(
+        &raw_scope_claim.scope_did,
+        &raw_scope_claim.investor_unique_id,
+    );
+    let scope_claim_proof_data = build_scope_claim_proof_data(&cdd_claim, &scope_claim);
+
+    let pair = ProofKeyPair::from(scope_claim_proof_data);
+    let proof = pair.generate_id_match_proof(&message).to_bytes().to_vec();
+
+    let cdd_id = compute_cdd_id(&cdd_claim);
+    let scope_id = compute_scope_id(&scope_claim);
+
+    // => Investor makes {cdd_id, investor_did, scope_id, scope_did, proof} public knowledge.
+    let packaged_proof = Proof {
+        cdd_id: cdd_id,
+        investor_did: raw_cdd_claim.investor_did,
+        scope_id: scope_id,
+        scope_did: raw_scope_claim.scope_did,
+        proof,
+    };
+    let proof_str = serde_json::to_string(&packaged_proof)
+        .unwrap_or_else(|error| panic!("Failed to serialize the proof: {}", error));
+
+    proof_str
 }

--- a/wasm_builder/src/lib.rs
+++ b/wasm_builder/src/lib.rs
@@ -1,12 +1,73 @@
-use cryptography::BALANCE_RANGE;
+use cryptography::claim_proofs::{compute_cdd_id, CddClaimData};
+use curve25519_dalek::ristretto::RistrettoPoint;
+use rand::{rngs::StdRng, SeedableRng};
+use rand_core::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
+
+pub type InvestorDID = [u8; 32];
+pub const INVESTORDID_LEN: usize = 32;
+
+// Ticker, a 12 bytes slice, is the scope DID.
+pub type ScopeDID = [u8; 12];
+pub const SCOPEDID_LEN: usize = 12;
+
+// Unique ID is a UUIDv4.
+pub type UniqueID = [u8; 16];
+pub const UNIQUEID_LEN: usize = 16;
 
 #[wasm_bindgen]
 extern "C" {
     pub fn alert(s: &str);
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CddId {
+    pub cdd_id: RistrettoPoint,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RawCddClaimData {
+    pub investor_did: InvestorDID,
+    pub investor_unique_id: UniqueID,
+}
+
+/// Generate a random `InvestorDID` for experiments.
+fn random_investor_did<R: RngCore + CryptoRng>(rng: &mut R) -> InvestorDID {
+    let mut investor_did = [0u8; INVESTORDID_LEN];
+    rng.fill_bytes(&mut investor_did);
+    investor_did
+}
+
+/// Generate a random `UniqueID` for experiments.
+fn random_unique_id<R: RngCore + CryptoRng>(rng: &mut R) -> UniqueID {
+    let mut unique_id = [0u8; UNIQUEID_LEN];
+    rng.fill_bytes(&mut unique_id);
+    unique_id
+}
+
+fn process_create_cdd_id() -> String {
+    let mut rng = StdRng::from_seed([42u8; 32]);
+    let rand_investor_did = random_investor_did(&mut rng);
+    let rand_unique_id = random_unique_id(&mut rng);
+    let raw_cdd_data = RawCddClaimData {
+        investor_did: rand_investor_did,
+        investor_unique_id: rand_unique_id,
+    };
+
+    let cdd_claim = CddClaimData::new(&raw_cdd_data.investor_did, &raw_cdd_data.investor_unique_id);
+
+    let cdd_id = compute_cdd_id(&cdd_claim);
+
+    // => CDD provider includes the CDD Id in their claim and submits it to the PolyMesh.
+    let packaged_cdd_id = CddId { cdd_id: cdd_id };
+    let cdd_id_str = serde_json::to_string(&packaged_cdd_id)
+        .unwrap_or_else(|error| panic!("Failed to serialize the CDD Id: {}", error));
+
+    cdd_id_str
+}
+
 #[wasm_bindgen]
 pub fn greet(name: &str) {
-    alert(&format!("Hello, {}!, {}", name, BALANCE_RANGE));
+    alert(&format!("Hello, {}!, {}", name, process_create_cdd_id()));
 }

--- a/wasm_builder/src/lib.rs
+++ b/wasm_builder/src/lib.rs
@@ -1,3 +1,4 @@
+use cryptography::BALANCE_RANGE;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -7,5 +8,5 @@ extern "C" {
 
 #[wasm_bindgen]
 pub fn greet(name: &str) {
-    alert(&format!("Hello, {}!", name));
+    alert(&format!("Hello, {}!, {}", name, BALANCE_RANGE));
 }

--- a/wasm_builder/src/lib.rs
+++ b/wasm_builder/src/lib.rs
@@ -1,25 +1,12 @@
 use cryptography::claim_proofs::{compute_cdd_id, CddClaimData};
 use curve25519_dalek::ristretto::RistrettoPoint;
-use rand::{rngs::StdRng, SeedableRng};
-use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-pub type InvestorDID = [u8; 32];
-pub const INVESTORDID_LEN: usize = 32;
-
-// Ticker, a 12 bytes slice, is the scope DID.
-pub type ScopeDID = [u8; 12];
-pub const SCOPEDID_LEN: usize = 12;
+type InvestorDID = [u8; 32];
 
 // Unique ID is a UUIDv4.
-pub type UniqueID = [u8; 16];
-pub const UNIQUEID_LEN: usize = 16;
-
-#[wasm_bindgen]
-extern "C" {
-    pub fn alert(s: &str);
-}
+type UniqueID = [u8; 16];
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CddId {
@@ -32,42 +19,26 @@ pub struct RawCddClaimData {
     pub investor_unique_id: UniqueID,
 }
 
-/// Generate a random `InvestorDID` for experiments.
-fn random_investor_did<R: RngCore + CryptoRng>(rng: &mut R) -> InvestorDID {
-    let mut investor_did = [0u8; INVESTORDID_LEN];
-    rng.fill_bytes(&mut investor_did);
-    investor_did
-}
-
-/// Generate a random `UniqueID` for experiments.
-fn random_unique_id<R: RngCore + CryptoRng>(rng: &mut R) -> UniqueID {
-    let mut unique_id = [0u8; UNIQUEID_LEN];
-    rng.fill_bytes(&mut unique_id);
-    unique_id
-}
-
-fn process_create_cdd_id() -> String {
-    let mut rng = StdRng::from_seed([42u8; 32]);
-    let rand_investor_did = random_investor_did(&mut rng);
-    let rand_unique_id = random_unique_id(&mut rng);
-    let raw_cdd_data = RawCddClaimData {
-        investor_did: rand_investor_did,
-        investor_unique_id: rand_unique_id,
-    };
+/// Creates a CDD_ID from investor did and investor uid
+///
+/// # Arguments
+/// * `cdd_claim` a stringified json with the following format:
+///   { "investor_did": [32_bytes_array], "investor_unique_id": [16_bytes_array] }
+///
+/// # Errors
+/// * `TODO` panicing at the moment.
+#[wasm_bindgen]
+pub fn process_create_cdd_id(cdd_claim: String) -> String {
+    let raw_cdd_data: RawCddClaimData = serde_json::from_str(&cdd_claim)
+        .unwrap_or_else(|error| panic!("Failed to deserialize the cdd claim: {}", error));
 
     let cdd_claim = CddClaimData::new(&raw_cdd_data.investor_did, &raw_cdd_data.investor_unique_id);
 
     let cdd_id = compute_cdd_id(&cdd_claim);
 
-    // => CDD provider includes the CDD Id in their claim and submits it to the PolyMesh.
     let packaged_cdd_id = CddId { cdd_id: cdd_id };
     let cdd_id_str = serde_json::to_string(&packaged_cdd_id)
         .unwrap_or_else(|error| panic!("Failed to serialize the CDD Id: {}", error));
 
     cdd_id_str
-}
-
-#[wasm_bindgen]
-pub fn greet(name: &str) {
-    alert(&format!("Hello, {}!, {}", name, process_create_cdd_id()));
 }


### PR DESCRIPTION
This is PR exposes some of the cryptography API in form a WASM build. Its main purpose is to take care of input/output conversion between the web and core cryptography API.

Questions:
1. Should this functionality be performed here or moved to the cli directory (for example under `cli/cil`)?
2. Do we want to export the result as an npm library or just build a wasm binary in our CI?

The code is very similar to the one implemented in `cli/cil/scp/src/lib.rs` therefore from the code re-use point-of-view moving this to that directory makes sense. But at the same time this is not a CLI...