### PR TITLE
Private Identity Audit Library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ members = [
 	"confidential-identity/cli/scp",
 	"confidential-identity/cli/scv",
 	"confidential-identity/wasm",
+	"private-identity-audit",
 ]

--- a/confidential-identity/src/pedersen_commitments.rs
+++ b/confidential-identity/src/pedersen_commitments.rs
@@ -79,7 +79,7 @@ pub struct PedersenGenerators {
     /// generator, G0, is the hash of G2 in points format, and the
     /// second generator, G1, is the hash of G0 converted to a
     /// Ristretto point.
-    generators: [RistrettoPoint; PEDERSEN_COMMITMENT_NUM_GENERATORS],
+    pub generators: [RistrettoPoint; PEDERSEN_COMMITMENT_NUM_GENERATORS],
 }
 
 impl Default for PedersenGenerators {

--- a/private-identity-audit/Cargo.toml
+++ b/private-identity-audit/Cargo.toml
@@ -17,9 +17,7 @@ serde = { version = "1.0.105", default-features = false, features = ["derive"], 
 uuid = { version = "0.8.1", features = ["serde", "v4"], optional = true }
 failure = { version = "0.1.7", default-features = false, features = ["derive"], optional = true }
 blake2 = { version = "0.9.0", default-features = false }
-merlin = { version = "2.0.0", default-features = false }
 sha3 = { version = "0.8", default-features = false }
-
 
 [features]
 default = ["std"]
@@ -42,6 +40,5 @@ std = [
     "failure/std",
     "uuid/std",
     "blake2/std",
-    "merlin/std",
 ]
 

--- a/private-identity-audit/Cargo.toml
+++ b/private-identity-audit/Cargo.toml
@@ -17,14 +17,16 @@ serde = { version = "1.0.105", default-features = false, features = ["derive"], 
 uuid = { version = "0.8.1", features = ["serde", "v4"], optional = true }
 failure = { version = "0.1.7", default-features = false, features = ["derive"], optional = true }
 blake2 = { version = "0.9.0", default-features = false }
+merlin = { version = "2.0.0", default-features = false }
+sha3 = { version = "0.8", default-features = false }
 
 
 [features]
 default = ["std"]
 
 serde_all = [
-	"serde",
-	"cryptography_core/serde_all",
+    "serde",
+    "cryptography_core/serde_all",
 ]
 
 no_std = [
@@ -32,14 +34,15 @@ no_std = [
 ]
 
 std = [
-	"serde_all",
-	"cryptography_core/std",
-	"confidential_identity/std",
-	"rand_core/std",
-	"rand/std",
+    "serde_all",
+    "cryptography_core/std",
+    "confidential_identity/std",
+    "rand_core/std",
+    "rand/std",
     "failure/std",
     "uuid/std",
     "blake2/std",
+    "merlin/std",
 ]
 
 

--- a/private-identity-audit/Cargo.toml
+++ b/private-identity-audit/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "private_identity_audit"
+version = "0.1.0"
+authors = [ "Polymath Inc" ]
+repository = "https://github.com/PolymathNetwork/cryptography"
+description = "The Private Identity Audit Library."
+readme = "README.md"
+edition = "2018"
+exclude = [".gitignore"]
+
+[dependencies]
+cryptography_core = { path = "../cryptography-core/", default_features = false }
+confidential_identity = { path = "../confidential-identity", default_features = false }
+rand_core = { version = "0.5", default-features = false}
+rand = { version = "0.7", default-features = false }
+serde = { version = "1.0.105", default-features = false, features = ["derive"], optional = true }
+uuid = { version = "0.8.1", features = ["serde", "v4"], optional = true }
+failure = { version = "0.1.7", default-features = false, features = ["derive"], optional = true }
+blake2 = { version = "0.9.0", default-features = false }
+
+
+[features]
+default = ["std"]
+
+serde_all = [
+	"serde",
+	"cryptography_core/serde_all",
+]
+
+no_std = [
+    "cryptography_core/no_std",
+]
+
+std = [
+	"serde_all",
+	"cryptography_core/std",
+	"confidential_identity/std",
+	"rand_core/std",
+	"rand/std",
+    "failure/std",
+    "uuid/std",
+    "blake2/std",
+]
+
+

--- a/private-identity-audit/Cargo.toml
+++ b/private-identity-audit/Cargo.toml
@@ -45,4 +45,3 @@ std = [
     "merlin/std",
 ]
 
-

--- a/private-identity-audit/src/errors.rs
+++ b/private-identity-audit/src/errors.rs
@@ -50,6 +50,10 @@ impl fmt::Display for Error {
 
 #[derive(Fail, Clone, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
+    /// ZKP initial message gen failed.
+    #[fail(display = "Error in generating initial ZKP message")]
+    InitialMessageGenError,
+
     /// ZKP proof failed.
     #[fail(display = "ZK Proof of {} failed", kind)]
     ZKPVerificationError { kind: String },

--- a/private-identity-audit/src/errors.rs
+++ b/private-identity-audit/src/errors.rs
@@ -1,0 +1,58 @@
+use failure::{Backtrace, Context, Fail};
+
+use std::{fmt, result::Result};
+
+/// Represents PIAL errors.
+#[derive(Debug)]
+pub struct Error {
+    inner: Context<ErrorKind>,
+}
+
+impl Error {
+    #[inline]
+    pub fn kind(&self) -> &ErrorKind {
+        self.inner.get_context()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    #[inline]
+    fn from(kind: ErrorKind) -> Error {
+        Error {
+            inner: Context::new(kind),
+        }
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    #[inline]
+    fn from(inner: Context<ErrorKind>) -> Error {
+        Error { inner }
+    }
+}
+
+impl Fail for Error {
+    fn cause(&self) -> Option<&dyn Fail> {
+        self.inner.cause()
+    }
+
+    #[inline]
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+#[derive(Fail, Clone, Debug, Eq, PartialEq)]
+pub enum ErrorKind {
+    /// TODO
+    #[fail(display = "TODO")]
+    TODOError,
+}
+
+pub type Fallible<T, E = Error> = Result<T, E>;

--- a/private-identity-audit/src/errors.rs
+++ b/private-identity-audit/src/errors.rs
@@ -50,9 +50,17 @@ impl fmt::Display for Error {
 
 #[derive(Fail, Clone, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
-    /// TODO
-    #[fail(display = "TODO")]
-    TODOError,
+    /// ZKP proof failed.
+    #[fail(display = "ZK Proof of {} failed", kind)]
+    ZKPVerificationError { kind: String },
+
+    /// Membership proof failed.
+    #[fail(display = "Membership proof failed")]
+    MembershipProofError,
+
+    /// CDD_ID mismatched.
+    #[fail(display = "CDD ID in the proof is different from the CDD ID of the chain.")]
+    CDDIdMismatchError,
 }
 
 pub type Fallible<T, E = Error> = Result<T, E>;

--- a/private-identity-audit/src/lib.rs
+++ b/private-identity-audit/src/lib.rs
@@ -19,25 +19,19 @@ use rand_core::{CryptoRng, RngCore};
 use uuid::Uuid;
 
 /// This is a security parameter. The larger the value, the higher the security guarantees.
-/// This value is used to pad the set of private unique ids set such that the encrypted set,
+/// This value is used to pad the set of private unique ids such that the set,
 /// has at least this many element. As a result when a CDD Provider proves that it holds an
 /// element of a set, PUIS can guess that element with probability 1/the_size_of_the_padded_set.
 pub const SET_SIZE_ANONYMITY_PARAM: usize = 100_000;
 
 /// The initial private set of PUIS.
-pub type PrivateUIDs = Vec<Scalar>;
+pub type PrivateUids = Vec<Scalar>;
 
-/// The encrypted and padded version of the private set of PUIS.
-pub type EncryptedUIDs = Vec<RistrettoPoint>;
+/// The committed and padded version of the private set of PUIS.
+pub type CommittedUids = Vec<RistrettoPoint>;
 
 /// The Zero-Knowledge challenge.
 pub type Challenge = Scalar;
-
-/// Committed CDD ID.
-pub type CommittedCDDID = RistrettoPoint;
-
-/// Committed version of the second half CDD ID.
-pub type CommittedSecondHalfCDDID = RistrettoPoint;
 
 /// Holds the information about the investor. The DID is public while the uID is private
 /// to the CDD Provider.
@@ -51,6 +45,10 @@ pub struct Proofs {
     cdd_id_proof: InitialMessage,
     cdd_id_second_half_proof: InitialMessage,
     uid_commitment_proof: InitialMessage,
+    /// Committed CDD ID. Corresponding to g^uID * h^DID * f^{hash(uID, DID)}`.
+    a: RistrettoPoint,
+    /// Committed version of the second half CDD ID. Corresponding to (h^DID*f^{hash(uID, DID)})^r
+    b: RistrettoPoint,
 }
 
 /// Holds the CDD Provider's response to the PUIS challenge.
@@ -96,23 +94,15 @@ pub trait ProofGenerator {
     /// * `ProverSecrets`: the secret values of PUIS. These are needed in the later steps of
     ///    the protocol and should be stored locally.
     /// * `Proofs`: The initial messages of ZKPs.
-    /// * `CommittedCDDID`: committed version of CDD ID.
-    /// * `CommittedSecondHalfCDDID`: corresponds to the committed version of
-    ///   `h^DID * f^{hash(uID, DID)}`.
     fn generate_initial_proofs<T: RngCore + CryptoRng>(
         investor: InvestorID,
         rng: &mut T,
-    ) -> Fallible<(
-        ProverSecrets,
-        Proofs,
-        CommittedCDDID,
-        CommittedSecondHalfCDDID,
-    )>;
+    ) -> Fallible<(ProverSecrets, Proofs)>;
 }
 
 /// Represents the second leg of protocol from PUIS to CDD Provider.
 pub trait ChallengeGenerator {
-    /// This is called by PUIS to create an encrypted version of the set of all unique
+    /// This is called by PUIS to create an committed version of the set of all unique
     /// identity IDs (uID). Moreover, it generates the random ZKP challenge.
     ///
     /// # Arguments
@@ -125,15 +115,15 @@ pub trait ChallengeGenerator {
     /// # Outputs
     /// * `VerifierSecrets`: the secret values of PUIS. These are needed in later steps of
     ///    the protocol and need to be stored locally.
-    /// * `EncryptedUIDs`: the padded, encrypted, and shuffled set of uIDs. These should
+    /// * `CommittedUids`: the padded, committed, and shuffled set of uIDs. These should
     ///    be sent to CDD Provider.
     /// * `Challenge`: the ZKP random challenge.
-    fn generate_encrypted_set_and_challenge<T: RngCore + CryptoRng>(
+    fn generate_committed_set_and_challenge<T: RngCore + CryptoRng>(
         &self,
-        private_unique_identifiers: PrivateUIDs,
+        private_unique_identifiers: PrivateUids,
         min_set_size: Option<usize>,
         rng: &mut T,
-    ) -> Fallible<(VerifierSecrets, EncryptedUIDs, Challenge)>;
+    ) -> Fallible<(VerifierSecrets, CommittedUids, Challenge)>;
 }
 
 /// Represents the third leg of the protocol from CDD Provider to PUIS.
@@ -143,33 +133,30 @@ pub trait ChallengeResponder {
     ///
     /// # Arguments
     /// * `secrets`: CDD Provider secrets that were generated in the first step of the protocol.
-    /// * `encrypted_uids`: the list of encrypted uIDs received from PUIS.
+    /// * `committed_uids`: the list of committed uIDs received from PUIS.
     /// * `challenge`: ZKP challenge received from PUIS.
     /// * `rng`: Cryptographically secure random number generator.
     ///
     /// # Outputs
     /// * `ProverFinalResponse`: The ZKP response.
-    /// * `EncryptedUIDs`: These re-encrypted uIDs form part of the proof of membership.
+    /// * `CommittedUids`: These re-committed uIDs form part of the proof of membership.
     fn generate_challenge_response<T: RngCore + CryptoRng>(
         secrets: ProverSecrets,
-        encrypted_uids: EncryptedUIDs,
+        committed_uids: CommittedUids,
         challenge: Scalar,
         rng: &mut T,
-    ) -> Fallible<(ProverFinalResponse, EncryptedUIDs)>;
+    ) -> Fallible<(ProverFinalResponse, CommittedUids)>;
 }
 
 /// Represents the last step of the protocol were PUIS verifies the proofs.
 pub trait ProofVerifier {
-    /// PUIS verifies both the ZKP proofs around CDD_ID and the proof of membership.
+    /// PUIS verifies both the ZKP proofs around CDD ID and the proof of membership.
     ///
     /// # Arguments
-    /// * `initial_message`: Initial messages of ZKP proofs of CDD_ID.
-    /// * `final_response`: Final responses of ZKP proofs of CDD_ID.
+    /// * `initial_message`: Initial messages of ZKP proofs of CDD ID.
+    /// * `final_response`: Final responses of ZKP proofs of CDD ID.
     /// * `challenge`: The ZKP challenge generated by PUIS.
-    /// * `cdd_id`: The CDD_ID read from the chain.
-    /// * `committed_cdd_id`: The committed CDD_ID received from CDD Provider.
-    /// * `committed_cdd_id_second_half`: The committed version of the second half of CDD_ID
-    ///    received from CDD Provider.
+    /// * `cdd_id`: The CDD ID read from the chain.
     /// * `verifier_secrets`: The PUIS secrets generated in the second step of the protocol.
     /// * `rng`: Cryptographically secure random number generator.
     fn verify_proofs(
@@ -177,78 +164,7 @@ pub trait ProofVerifier {
         final_response: ProverFinalResponse,
         challenge: Scalar,
         cdd_id: RistrettoPoint,
-        committed_cdd_id: RistrettoPoint,
-        committed_cdd_id_second_half: RistrettoPoint,
         verifier_secrets: VerifierSecrets,
-        re_encrypted_uids: EncryptedUIDs,
+        re_committed_uids: CommittedUids,
     ) -> Fallible<()>;
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{
-        prover::{generate_bliding_factor, FinalProver, InitialProver},
-        uuid_to_scalar,
-        verifier::{gen_random_uuids, Verifier, VerifierSetGenerator},
-        ChallengeGenerator, ChallengeResponder, InvestorID, ProofGenerator, ProofVerifier,
-    };
-    use confidential_identity::pedersen_commitments::PedersenGenerators;
-    use cryptography_core::curve25519_dalek::scalar::Scalar;
-    use rand::{rngs::StdRng, SeedableRng};
-
-    #[test]
-    fn test_success_end_to_end() {
-        let mut rng = StdRng::from_seed([10u8; 32]);
-        let pg = PedersenGenerators::default();
-
-        // Private input of the Verifier.
-        let private_uid_set: Vec<Scalar> = gen_random_uuids(100, &mut rng)
-            .into_iter()
-            .map(|uuid| uuid_to_scalar(uuid))
-            .collect();
-
-        // Verifier shares one of its uids with the Prover.
-        let investor = InvestorID {
-            uid: private_uid_set[0],
-            did: Scalar::random(&mut rng),
-        };
-
-        // Prover generates cdd_id and places it on the chain.
-        let cdd_id = pg.commit(&[
-            investor.uid,
-            investor.did,
-            generate_bliding_factor(investor.uid, investor.did),
-        ]);
-
-        // P -> V: Prover generates and sends the initial message.
-        let (prover_secrets, proofs, committed_cdd_id, committed_cdd_id_second_half) =
-            InitialProver::generate_initial_proofs(investor, &mut rng).unwrap();
-
-        // V -> P: Prover sends `proofs` and Verifier returns a list of 10 uids and the challenge.
-        let (verifier_secrets, encrypted_uids, challenge) = VerifierSetGenerator
-            .generate_encrypted_set_and_challenge(private_uid_set, Some(100), &mut rng)
-            .unwrap();
-
-        // P -> V: Verifier sends the encrypted_uids and the challenge to the Prover.
-        let (prover_response, re_encrypted_uids) = FinalProver::generate_challenge_response(
-            prover_secrets,
-            encrypted_uids,
-            challenge,
-            &mut rng,
-        )
-        .unwrap();
-
-        // Only V: Verifier verifies the proofs and check membership.
-        Verifier::verify_proofs(
-            proofs,
-            prover_response,
-            challenge,
-            cdd_id,
-            committed_cdd_id,
-            committed_cdd_id_second_half,
-            verifier_secrets,
-            re_encrypted_uids,
-        )
-        .unwrap();
-    }
 }

--- a/private-identity-audit/src/lib.rs
+++ b/private-identity-audit/src/lib.rs
@@ -6,6 +6,8 @@
 #![feature(iterator_fold_self)]
 
 mod errors;
+#[macro_use]
+mod macros;
 mod proofs;
 mod prover;
 mod verifier;
@@ -15,24 +17,6 @@ use errors::Fallible;
 use proofs::{FinalResponse, InitialMessage, Secrets};
 use rand_core::{CryptoRng, RngCore};
 use uuid::Uuid;
-
-/// That `ensure` does not transform into a string representation like `failure::ensure` is doing.
-#[allow(unused_macros)]
-macro_rules! ensure {
-    ($predicate:expr, $context_selector:expr) => {
-        if !$predicate {
-            return Err($context_selector.into());
-        }
-    };
-}
-
-/// Helper macro to assert that `predicate` is an `Error::from( $err)`.
-#[allow(unused_macros)]
-macro_rules! assert_err {
-    ($predicate:expr, $err:expr) => {
-        assert_eq!($predicate.expect_err("Error expected").kind(), &$err);
-    };
-}
 
 /// This is a security parameter. The larger the value, the higher the security guarantees.
 /// This value is used to pad the set of private unique ids set such that the encrypted set,

--- a/private-identity-audit/src/lib.rs
+++ b/private-identity-audit/src/lib.rs
@@ -1,0 +1,74 @@
+//! pial is the library that implements the private identity audit protocol
+//! of the PIAL, as defined in the section TODO of the whitepaper TODO.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+mod errors;
+mod verifier;
+use cryptography_core::curve25519_dalek::ristretto::RistrettoPoint;
+use errors::Fallible;
+use rand_core::{CryptoRng, RngCore};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// That `ensure` does not transform into a string representation like `failure::ensure` is doing.
+#[allow(unused_macros)]
+macro_rules! ensure {
+    ($predicate:expr, $context_selector:expr) => {
+        if !$predicate {
+            return Err($context_selector.into());
+        }
+    };
+}
+
+/// Helper macro to assert that `predicate` is an `Error::from( $err)`.
+#[allow(unused_macros)]
+macro_rules! assert_err {
+    ($predicate:expr, $err:expr) => {
+        assert_eq!($predicate.expect_err("Error expected").kind(), &$err);
+    };
+}
+
+/// This is a security parameter. The larger the value, the higher the security guarantees.
+/// This value is used to pad the set of private unique ids set such that the encrypted set,
+/// has at least this many element. As a result when a CDD Provider proves that it holds an
+/// element of a set, PUIS can guess that element with probability 1/the_size_of_the_padded_set.
+pub const SET_SIZE_ANONYMITY_PARAM: usize = 100_000;
+
+pub type PrivateUIDs = Vec<Uuid>;
+pub type EncryptedUIDs = Vec<RistrettoPoint>;
+pub struct MultipartCDDId {
+    part1: RistrettoPoint,
+    part2: RistrettoPoint,
+}
+pub struct Proof();
+
+pub trait PrivateSetGenerator {
+    /// This is called by PUIS to create an encrypted version of the set of all unique
+    /// identity IDs (uID).
+    ///
+    /// # Arguments
+    /// * `private_unique_identifiers`: A list of UUIDs that represent the private set of
+    ///   unique identifiers.
+    /// * `min_set_size`: An optional parameter to override the default value of
+    /// `SET_SIZE_ANONYMITY_PARAM`.
+    fn generate_encrypted_unique_ids<T: RngCore + CryptoRng>(
+        &self,
+        private_unique_identifiers: PrivateUIDs,
+        min_set_size: Option<usize>,
+        rng: &mut T,
+    ) -> Fallible<EncryptedUIDs>;
+}
+
+pub trait ProofGenerator {
+    fn generate_membership_proof<T: RngCore + CryptoRng>(
+        cdd_id: MultipartCDDId,
+        encrypted_uids: EncryptedUIDs,
+        rng: T,
+    ) -> Fallible<Proof>;
+}
+
+pub trait ProofVerifier {
+    fn verify_membership_proof(proof: Proof, encrypted_uids: EncryptedUIDs) -> Fallible<()>;
+}

--- a/private-identity-audit/src/lib.rs
+++ b/private-identity-audit/src/lib.rs
@@ -12,6 +12,7 @@ mod proofs;
 mod prover;
 mod verifier;
 use blake2::{Blake2b, Digest};
+use confidential_identity::CddClaimData;
 use cryptography_core::curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
 use errors::Fallible;
 use proofs::{FinalResponse, InitialMessage, Secrets};
@@ -32,13 +33,6 @@ pub type CommittedUids = Vec<RistrettoPoint>;
 
 /// The Zero-Knowledge challenge.
 pub type Challenge = Scalar;
-
-/// Holds the information about the investor. The DID is public while the uID is private
-/// to the CDD Provider.
-pub struct InvestorID {
-    did: Scalar,
-    uid: Scalar,
-}
 
 /// Holds the initial messages in the Zero-Knowledge Proofs sent by CDD Provider.
 pub struct Proofs {
@@ -95,7 +89,7 @@ pub trait ProofGenerator {
     ///    the protocol and should be stored locally.
     /// * `Proofs`: The initial messages of ZKPs.
     fn generate_initial_proofs<T: RngCore + CryptoRng>(
-        investor: InvestorID,
+        investor: CddClaimData,
         rng: &mut T,
     ) -> Fallible<(ProverSecrets, Proofs)>;
 }

--- a/private-identity-audit/src/lib.rs
+++ b/private-identity-audit/src/lib.rs
@@ -14,8 +14,6 @@ use cryptography_core::curve25519_dalek::{ristretto::RistrettoPoint, scalar::Sca
 use errors::Fallible;
 use proofs::{FinalResponse, InitialMessage, Secrets};
 use rand_core::{CryptoRng, RngCore};
-//#[cfg(feature = "serde")]
-//use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// That `ensure` does not transform into a string representation like `failure::ensure` is doing.
@@ -42,27 +40,43 @@ macro_rules! assert_err {
 /// element of a set, PUIS can guess that element with probability 1/the_size_of_the_padded_set.
 pub const SET_SIZE_ANONYMITY_PARAM: usize = 100_000;
 
-pub type PrivateUIDs = Vec<Uuid>;
+/// The initial private set of PUIS.
+pub type PrivateUIDs = Vec<Scalar>;
 
+/// The encrypted and padded version of the private set of PUIS.
 pub type EncryptedUIDs = Vec<RistrettoPoint>;
 
+/// The Zero-Knowledge challenge.
+pub type Challenge = Scalar;
+
+/// Committed CDD ID.
+pub type CommittedCDDID = RistrettoPoint;
+
+/// Committed version of the second half CDD ID.
+pub type CommittedSecondHalfCDDID = RistrettoPoint;
+
+/// Holds the information about the investor. The DID is public while the uID is private
+/// to the CDD Provider.
 pub struct InvestorID {
     did: Scalar,
     uid: Scalar,
 }
 
+/// Holds the initial messages in the Zero-Knowledge Proofs sent by CDD Provider.
 pub struct Proofs {
     cdd_id_proof: InitialMessage,
     cdd_id_second_half_proof: InitialMessage,
     uid_commitment_proof: InitialMessage,
 }
 
+/// Holds the CDD Provider's response to the PUIS challenge.
 pub struct ProverFinalResponse {
     cdd_id_proof_response: FinalResponse,
     cdd_id_second_half_proof_response: FinalResponse,
     uid_commitment_proof_response: FinalResponse,
 }
 
+/// Holds CDD Provider secret data.
 pub struct ProverSecrets {
     cdd_id_proof_secrets: Secrets,
     cdd_id_second_half_proof_secrets: Secrets,
@@ -70,6 +84,7 @@ pub struct ProverSecrets {
     rand: Scalar,
 }
 
+/// Holds PUIS secret data.
 pub struct VerifierSecrets {
     rand: Scalar,
 }
@@ -82,30 +97,75 @@ pub fn uuid_to_scalar(uuid: Uuid) -> Scalar {
     Scalar::from_bytes_mod_order_wide(&hash)
 }
 
-pub trait PrivateSetGenerator {
-    /// This is called by PUIS to create an encrypted version of the set of all unique
-    /// identity IDs (uID).
+/// Represents the first leg of the protocol from CDD Provider to PUIS.
+pub trait ProofGenerator {
+    /// This is called by the CDD Provider in the first step of the protocol to generate
+    /// initial ZKP proofs that CDD Provider knows a `uID` and a `DID` such that
+    ///
+    /// `CDD_ID = g^uID * h^DID * f^{hash(uID, DID)}` for some pre-determined `g, h, and f`.
     ///
     /// # Arguments
-    /// * `private_unique_identifiers`: A list of UUIDs that represent the private set of
-    ///   unique identifiers.
+    /// * `investor`: Holds the uID and DID of the investor.
+    /// * `rng`: Cryptographically secure random number generator.
+    ///
+    /// # Outputs
+    /// * `ProverSecrets`: the secret values of PUIS. These are needed in the later steps of
+    ///    the protocol and should be stored locally.
+    /// * `Proofs`: The initial messages of ZKPs.
+    /// * `CommittedCDDID`: committed version of CDD ID.
+    /// * `CommittedSecondHalfCDDID`: corresponds to the committed version of
+    ///   `h^DID * f^{hash(uID, DID)}`.
+    fn generate_initial_proofs<T: RngCore + CryptoRng>(
+        investor: InvestorID,
+        rng: &mut T,
+    ) -> Fallible<(
+        ProverSecrets,
+        Proofs,
+        CommittedCDDID,
+        CommittedSecondHalfCDDID,
+    )>;
+}
+
+/// Represents the second leg of protocol from PUIS to CDD Provider.
+pub trait ChallengeGenerator {
+    /// This is called by PUIS to create an encrypted version of the set of all unique
+    /// identity IDs (uID). Moreover, it generates the random ZKP challenge.
+    ///
+    /// # Arguments
+    /// * `private_unique_identifiers`: A list of Scalars that represent the private set of
+    ///   unique identifiers. Call `uuid_to_scalar` to convert uIDs to Scalar properly.
     /// * `min_set_size`: An optional parameter to override the default value of
     /// `SET_SIZE_ANONYMITY_PARAM`.
-    fn generate_encrypted_unique_ids<T: RngCore + CryptoRng>(
+    /// * `rng`: Cryptographically secure random number generator.
+    ///
+    /// # Outputs
+    /// * `VerifierSecrets`: the secret values of PUIS. These are needed in later steps of
+    ///    the protocol and need to be stored locally.
+    /// * `EncryptedUIDs`: the padded, encrypted, and shuffled set of uIDs. These should
+    ///    be sent to CDD Provider.
+    /// * `Challenge`: the ZKP random challenge.
+    fn generate_encrypted_set_and_challenge<T: RngCore + CryptoRng>(
         &self,
         private_unique_identifiers: PrivateUIDs,
         min_set_size: Option<usize>,
         rng: &mut T,
-    ) -> Fallible<(VerifierSecrets, EncryptedUIDs, Scalar)>;
+    ) -> Fallible<(VerifierSecrets, EncryptedUIDs, Challenge)>;
 }
 
-pub trait ProofGenerator {
-    fn generate_membership_proof<T: RngCore + CryptoRng>(
-        investor: InvestorID,
-        rng: &mut T,
-    ) -> Fallible<(ProverSecrets, Proofs, RistrettoPoint, RistrettoPoint)>;
-}
+/// Represents the third leg of the protocol from CDD Provider to PUIS.
 pub trait ChallengeResponder {
+    /// This is called by CDD Provider to generate the ZKP response of the challenge
+    /// and provide the proof of membership.
+    ///
+    /// # Arguments
+    /// * `secrets`: CDD Provider secrets that were generated in the first step of the protocol.
+    /// * `encrypted_uids`: the list of encrypted uIDs received from PUIS.
+    /// * `challenge`: ZKP challenge received from PUIS.
+    /// * `rng`: Cryptographically secure random number generator.
+    ///
+    /// # Outputs
+    /// * `ProverFinalResponse`: The ZKP response.
+    /// * `EncryptedUIDs`: These re-encrypted uIDs form part of the proof of membership.
     fn generate_challenge_response<T: RngCore + CryptoRng>(
         secrets: ProverSecrets,
         encrypted_uids: EncryptedUIDs,
@@ -114,8 +174,21 @@ pub trait ChallengeResponder {
     ) -> Fallible<(ProverFinalResponse, EncryptedUIDs)>;
 }
 
+/// Represents the last step of the protocol were PUIS verifies the proofs.
 pub trait ProofVerifier {
-    fn verify_membership_proof(
+    /// PUIS verifies both the ZKP proofs around CDD_ID and the proof of membership.
+    ///
+    /// # Arguments
+    /// * `initial_message`: Initial messages of ZKP proofs of CDD_ID.
+    /// * `final_response`: Final responses of ZKP proofs of CDD_ID.
+    /// * `challenge`: The ZKP challenge generated by PUIS.
+    /// * `cdd_id`: The CDD_ID read from the chain.
+    /// * `committed_cdd_id`: The committed CDD_ID received from CDD Provider.
+    /// * `committed_cdd_id_second_half`: The committed version of the second half of CDD_ID
+    ///    received from CDD Provider.
+    /// * `verifier_secrets`: The PUIS secrets generated in the second step of the protocol.
+    /// * `rng`: Cryptographically secure random number generator.
+    fn verify_proofs(
         initial_message: Proofs,
         final_response: ProverFinalResponse,
         challenge: Scalar,
@@ -133,7 +206,7 @@ mod tests {
         prover::{generate_bliding_factor, FinalProver, InitialProver},
         uuid_to_scalar,
         verifier::{gen_random_uuids, Verifier, VerifierSetGenerator},
-        ChallengeResponder, InvestorID, PrivateSetGenerator, ProofGenerator, ProofVerifier,
+        ChallengeGenerator, ChallengeResponder, InvestorID, ProofGenerator, ProofVerifier,
     };
     use confidential_identity::pedersen_commitments::PedersenGenerators;
     use cryptography_core::curve25519_dalek::scalar::Scalar;
@@ -144,26 +217,35 @@ mod tests {
         let mut rng = StdRng::from_seed([10u8; 32]);
         let pg = PedersenGenerators::default();
 
-        // Prover generates and sends the initial message.
-        let private_uid_set = gen_random_uuids(100, &mut rng);
+        // Private input of the Verifier.
+        let private_uid_set: Vec<Scalar> = gen_random_uuids(100, &mut rng)
+            .into_iter()
+            .map(|uuid| uuid_to_scalar(uuid))
+            .collect();
+
+        // Verifier shares one of its uids with the Prover.
         let investor = InvestorID {
-            uid: uuid_to_scalar(private_uid_set[0]),
+            uid: private_uid_set[0],
             did: Scalar::random(&mut rng),
         };
+
+        // Prover generates cdd_id and places it on the chain.
         let cdd_id = pg.commit(&[
             investor.uid,
             investor.did,
             generate_bliding_factor(investor.uid, investor.did),
         ]);
-        let (prover_secrets, proofs, committed_cdd_id, committed_cdd_id_second_half) =
-            InitialProver::generate_membership_proof(investor, &mut rng).unwrap();
 
-        // Prover sends `proofs` and Verifier returns a list of 10 uids and the challenge.
+        // P -> V: Prover generates and sends the initial message.
+        let (prover_secrets, proofs, committed_cdd_id, committed_cdd_id_second_half) =
+            InitialProver::generate_initial_proofs(investor, &mut rng).unwrap();
+
+        // V -> P: Prover sends `proofs` and Verifier returns a list of 10 uids and the challenge.
         let (verifier_secrets, encrypted_uids, challenge) = VerifierSetGenerator
-            .generate_encrypted_unique_ids(private_uid_set, Some(100), &mut rng)
+            .generate_encrypted_set_and_challenge(private_uid_set, Some(100), &mut rng)
             .unwrap();
 
-        // Verifier sends the encrytped_uids and the challenge to the Prover.
+        // P -> V: Verifier sends the encrypted_uids and the challenge to the Prover.
         let (prover_response, re_encrypted_uids) = FinalProver::generate_challenge_response(
             prover_secrets,
             encrypted_uids,
@@ -172,8 +254,8 @@ mod tests {
         )
         .unwrap();
 
-        // Verifier verifies the proofs and check membership.
-        Verifier::verify_membership_proof(
+        // Only V: Verifier verifies the proofs and check membership.
+        Verifier::verify_proofs(
             proofs,
             prover_response,
             challenge,

--- a/private-identity-audit/src/macros.rs
+++ b/private-identity-audit/src/macros.rs
@@ -1,0 +1,19 @@
+/// That `ensure` does not transform into a string representation like `failure::ensure` is doing.
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! ensure {
+    ($predicate:expr, $context_selector:expr) => {
+        if !$predicate {
+            return Err($context_selector.into());
+        }
+    };
+}
+
+/// Helper macro to assert that `predicate` is an `Error::from( $err)`.
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! assert_err {
+    ($predicate:expr, $err:expr) => {
+        assert_eq!($predicate.expect_err("Error expected").kind(), &$err);
+    };
+}

--- a/private-identity-audit/src/proofs.rs
+++ b/private-identity-audit/src/proofs.rs
@@ -1,14 +1,14 @@
-//! Provides interactive ZKP for statements of muliple base.
+//! Provides interactive ZKP for statements of multiple base.
 //!
 //! Statement: q=G^x
-//! ZKP(q, G):
+//! ZKP(q; G):
 //!   1. P -> V: A = G^r
 //!   2. V -> P: c
 //!   3. P -> V: s = r + c*x
 //!   4. V: G^s == A * q^c
 //!
 //! Statement: q=H^y*F^z
-//! ZKP(q, G):
+//! ZKP(q; H, F):
 //!   1. P -> V: A = H^r1 * F^r2
 //!   2. V -> P: c
 //!   3. P -> V: s1 = r1 + c*y, s2 = r2 + c*z
@@ -93,7 +93,7 @@ pub fn verify(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{prover::generate_bliding_factor, InvestorID};
+    use crate::{prover::generate_blinding_factor, InvestorID};
     use confidential_identity::pedersen_commitments::PedersenGenerators;
     use cryptography_core::curve25519_dalek::traits::MultiscalarMul;
     use rand::{rngs::StdRng, SeedableRng};
@@ -136,7 +136,7 @@ mod tests {
             uid: Scalar::random(&mut rng),
             did: Scalar::random(&mut rng),
         };
-        let blinding_factor = generate_bliding_factor(investor.did, investor.uid);
+        let blinding_factor = generate_blinding_factor(investor.did, investor.uid);
         let secrets = [investor.did, investor.uid, blinding_factor];
         let cdd_id = pg.commit(&secrets);
         let r = Scalar::random(&mut rng);

--- a/private-identity-audit/src/proofs.rs
+++ b/private-identity-audit/src/proofs.rs
@@ -77,16 +77,17 @@ pub fn verify(
     statement: RistrettoPoint,
     c: Challenge,
 ) -> bool {
-    let lhs = initial_message
+    if let Some(lhs) = initial_message
         .generators
         .into_iter()
         .zip(final_response.s)
         .map(|(gen, s)| gen * s)
         .fold_first(|v1, v2| v1 + v2)
-        .unwrap(); // TODO
-    let rhs = initial_message.a + statement * c;
+    {
+        return lhs == initial_message.a + statement * c;
+    }
 
-    lhs == rhs
+    false
 }
 
 #[cfg(test)]

--- a/private-identity-audit/src/proofs.rs
+++ b/private-identity-audit/src/proofs.rs
@@ -21,7 +21,7 @@ type Challenge = Scalar;
 #[derive(Clone)]
 pub struct InitialMessage {
     a: RistrettoPoint,
-    generators: Vec<RistrettoPoint>,
+    pub generators: Vec<RistrettoPoint>,
 }
 
 #[derive(Clone)]
@@ -97,7 +97,7 @@ mod tests {
     use rand::{rngs::StdRng, SeedableRng};
 
     #[test]
-    fn test_zkp_proof() {
+    fn test_zkp_multiple_base_proof() {
         let mut rng = StdRng::from_seed([42u8; 32]);
         let generators = vec![
             RistrettoPoint::random(&mut rng),

--- a/private-identity-audit/src/proofs.rs
+++ b/private-identity-audit/src/proofs.rs
@@ -1,0 +1,392 @@
+//! Statement: q=G^x
+//! ZKP(q, G):
+//!   1. P -> V: A = G^r
+//!   2. V -> P: c
+//!   3. P -> V: s = r + c*x
+//!   4. V: G^s == A * q^c
+//!
+//! Statement: q=H^y*F^z
+//! ZKP(q, G):
+//!   1. P -> V: A = H^r1 * F^r2
+//!   2. V -> P: c
+//!   3. P -> V: s1 = r1 + c*y, s2 = r2 + c*z
+//!   4. V: H^s1 * F^s2 == A * q^c
+//!
+
+use cryptography_core::{
+    asset_proofs::{
+        encryption_proofs::{
+            AssetProofProver, AssetProofProverAwaitingChallenge, AssetProofVerifier, ZKPChallenge,
+            ZKProofResponse,
+        },
+        transcript::{TranscriptProtocol, UpdateTranscript},
+    },
+    curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar},
+    errors::{ErrorKind as CoreErrorKind, Fallible as CoreFallible},
+};
+use merlin::{Transcript, TranscriptRng};
+use rand_core::{CryptoRng, RngCore};
+
+/// The domain label for the wellformedness proof.
+pub const WELLFORMEDNESS_PROOF_FINAL_RESPONSE_LABEL: &[u8] =
+    b"PIAL_PolymathWellformednessFinalResponse";
+/// The domain label for the challenge.
+pub const WELLFORMEDNESS_PROOF_CHALLENGE_LABEL: &[u8] =
+    b"PIAL_PolymathWellformednessProofChallenge";
+
+pub struct WellformednessInitialMessage {
+    a: RistrettoPoint,
+}
+
+pub struct WellformednessFinalResponse {
+    s: Vec<Scalar>,
+}
+
+impl UpdateTranscript for WellformednessInitialMessage {
+    fn update_transcript(&self, transcript: &mut Transcript) -> CoreFallible<()> {
+        transcript.append_domain_separator(WELLFORMEDNESS_PROOF_CHALLENGE_LABEL);
+        transcript.append_validated_point(b"A", &self.a.compress())?;
+        Ok(())
+    }
+}
+
+/// Holds the non-interactive proofs of wellformedness, equivalent of L_enc of the MERCAT paper.
+pub type WellformednessProof =
+    ZKProofResponse<WellformednessInitialMessage, WellformednessFinalResponse>;
+
+#[derive(Clone, Debug)]
+pub struct WellformednessProver {
+    /// The secret commitment witness.
+    secrets: Vec<Scalar>,
+    /// The randomness generate in the first round.
+    rands: Vec<Scalar>,
+}
+
+#[derive(Clone)]
+pub struct WellformednessProverAwaitingChallenge<'a> {
+    /// The secret commitment witness.
+    pub secrets: Vec<Scalar>,
+
+    /// The Pedersen generators.
+    pub generators: &'a Vec<RistrettoPoint>,
+}
+
+impl<'a> AssetProofProverAwaitingChallenge for WellformednessProverAwaitingChallenge<'a> {
+    type ZKInitialMessage = WellformednessInitialMessage;
+    type ZKFinalResponse = WellformednessFinalResponse;
+    type ZKProver = WellformednessProver;
+
+    fn create_transcript_rng<T: RngCore + CryptoRng>(
+        &self,
+        rng: &mut T,
+        transcript: &Transcript,
+    ) -> TranscriptRng {
+        (&self.secrets)
+            .into_iter()
+            .fold(transcript.build_rng(), |transcript_rng, secret| {
+                transcript_rng.rekey_with_witness_bytes(b"secret_value", secret.as_bytes())
+            })
+            .finalize(rng)
+    }
+
+    fn generate_initial_message(
+        &self,
+        rng: &mut TranscriptRng,
+    ) -> (Self::ZKProver, Self::ZKInitialMessage) {
+        let rands: Vec<Scalar> = vec![0; self.generators.len()]
+            .into_iter()
+            .map(|_| Scalar::random(rng))
+            .collect();
+        let a = self
+            .generators
+            .clone()
+            .into_iter()
+            .zip(&rands)
+            .map(|(gen, rand)| gen * rand)
+            .fold_first(|v1, v2| v1 + v2)
+            .unwrap();
+        (
+            WellformednessProver {
+                secrets: self.secrets.clone(),
+                rands,
+            },
+            WellformednessInitialMessage { a },
+        )
+    }
+}
+
+impl AssetProofProver<WellformednessFinalResponse> for WellformednessProver {
+    fn apply_challenge(&self, c: &ZKPChallenge) -> WellformednessFinalResponse {
+        let s = (&self.rands)
+            .into_iter()
+            .zip(&self.secrets)
+            .map(|(rand, secret)| rand + c.x() * secret)
+            .collect();
+        WellformednessFinalResponse { s }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct WellformednessVerifier<'a> {
+    pub statement: RistrettoPoint,
+    pub generators: &'a Vec<RistrettoPoint>,
+}
+
+impl<'a> AssetProofVerifier for WellformednessVerifier<'a> {
+    type ZKInitialMessage = WellformednessInitialMessage;
+    type ZKFinalResponse = WellformednessFinalResponse;
+
+    fn verify(
+        &self,
+        challenge: &ZKPChallenge,
+        initial_message: &Self::ZKInitialMessage,
+        response: &Self::ZKFinalResponse,
+    ) -> CoreFallible<()> {
+        let lhs = self
+            .generators
+            .into_iter()
+            .zip(&response.s)
+            .map(|(gen, s)| gen * s)
+            .fold_first(|v1, v2| v1 + v2)
+            .ok_or(CoreErrorKind::WellformednessFinalResponseVerificationError { check: 1 })?;
+        let rhs = initial_message.a + self.statement * challenge.x();
+
+        // TODO replace with ErrorKind and ensure
+        assert_eq!(lhs, rhs);
+
+        Ok(())
+    }
+}
+
+//#[cfg(test)]
+//mod tests {
+//    extern crate wasm_bindgen_test;
+//    use super::*;
+//    use crate::asset_proofs::encryption_proofs::{
+//        single_property_prover, single_property_verifier,
+//    };
+//    use crate::asset_proofs::*;
+//    use rand::{rngs::StdRng, SeedableRng};
+//    use sp_std::prelude::*;
+//    use wasm_bindgen_test::*;
+//
+//    const SEED_1: [u8; 32] = [42u8; 32];
+//
+//    #[test]
+//    #[wasm_bindgen_test]
+//    fn test_wellformedness_proof() {
+//        let gens = PedersenGens::default();
+//        let mut rng = StdRng::from_seed(SEED_1);
+//        let secret_value = 42u32;
+//
+//        let elg_secret = ElgamalSecretKey::new(Scalar::random(&mut rng));
+//        let pub_key = elg_secret.get_public_key();
+//        let (w, cipher) = pub_key.encrypt_value(secret_value.into(), &mut rng);
+//
+//        let prover = WellformednessProverAwaitingChallenge {
+//            pub_key,
+//            w: w.clone(),
+//            pc_gens: &gens,
+//        };
+//        let verifier = WellformednessVerifier {
+//            pub_key,
+//            cipher,
+//            pc_gens: &gens,
+//        };
+//        let mut dealer_transcript = Transcript::new(WELLFORMEDNESS_PROOF_FINAL_RESPONSE_LABEL);
+//
+//        // ------------------------------- Interactive case
+//        // Positive tests
+//        // 1st round
+//        let mut transcript_rng = prover.create_transcript_rng(&mut rng, &dealer_transcript);
+//        let (prover, initial_message) = prover.generate_initial_message(&mut transcript_rng);
+//
+//        // 2nd round
+//        initial_message
+//            .update_transcript(&mut dealer_transcript)
+//            .unwrap();
+//        let challenge = dealer_transcript
+//            .scalar_challenge(WELLFORMEDNESS_PROOF_CHALLENGE_LABEL)
+//            .unwrap();
+//
+//        // 3rd round
+//        let final_response = prover.apply_challenge(&challenge);
+//
+//        // 4th round
+//        // in the interactive case, verifier is the dealer and therefore, the challenge is saved
+//        // on the verifier side and passed to this function.
+//        let result = verifier.verify(&challenge, &initial_message, &final_response);
+//        assert!(result.is_ok());
+//
+//        // Negative tests
+//        let bad_initial_message = WellformednessInitialMessage::default();
+//        let result = verifier.verify(&challenge, &bad_initial_message, &final_response);
+//        assert_err!(
+//            result,
+//            ErrorKind::WellformednessFinalResponseVerificationError { check: 1 }
+//        );
+//
+//        let bad_final_response = WellformednessFinalResponse {
+//            z1: Scalar::default(),
+//            z2: Scalar::default(),
+//        };
+//        let result = verifier.verify(&challenge, &initial_message, &bad_final_response);
+//        assert_err!(
+//            result,
+//            ErrorKind::WellformednessFinalResponseVerificationError { check: 1 }
+//        );
+//
+//        // ------------------------------- Non-interactive case
+//        let prover = WellformednessProverAwaitingChallenge {
+//            pub_key,
+//            w: w,
+//            pc_gens: &gens,
+//        };
+//        let verifier = WellformednessVerifier {
+//            pub_key,
+//            cipher,
+//            pc_gens: &gens,
+//        };
+//
+//        // 1st to 3rd rounds
+//        let (initial_message, final_response) = single_property_prover::<
+//            StdRng,
+//            WellformednessProverAwaitingChallenge,
+//        >(prover, &mut rng)
+//        .unwrap();
+//
+//        // Positive test
+//        assert!(
+//            // 4th round
+//            single_property_verifier(&verifier, (initial_message, final_response)).is_ok()
+//        );
+//
+//        // Negative tests
+//        let bad_initial_message = WellformednessInitialMessage::default();
+//        assert_err!(
+//            // 4th round
+//            single_property_verifier(&verifier, (bad_initial_message, final_response)),
+//            ErrorKind::WellformednessFinalResponseVerificationError { check: 1 }
+//        );
+//
+//        assert_err!(
+//            // 4th round
+//            single_property_verifier(&verifier, (initial_message, bad_final_response)),
+//            ErrorKind::WellformednessFinalResponseVerificationError { check: 1 }
+//        );
+//    }
+//
+//    #[test]
+//    #[wasm_bindgen_test]
+//    fn serialize_deserialize_proof() {
+//        let mut rng = StdRng::from_seed(SEED_1);
+//        let secret_value = 42u32;
+//        let rand_blind = Scalar::random(&mut rng);
+//        let gens = PedersenGens::default();
+//        let w = CommitmentWitness::new(secret_value.into(), rand_blind);
+//        let elg_secret = ElgamalSecretKey::new(Scalar::random(&mut rng));
+//        let pub_key = elg_secret.get_public_key();
+//
+//        let prover = WellformednessProverAwaitingChallenge {
+//            pub_key,
+//            w: w,
+//            pc_gens: &gens,
+//        };
+//        let (initial_message, final_response) = encryption_proofs::single_property_prover::<
+//            StdRng,
+//            WellformednessProverAwaitingChallenge,
+//        >(prover, &mut rng)
+//        .unwrap();
+//
+//        let bytes = initial_message.encode();
+//        let mut input = bytes.as_slice();
+//        let recovered_initial_message = <WellformednessInitialMessage>::decode(&mut input).unwrap();
+//        assert_eq!(recovered_initial_message, initial_message);
+//
+//        let bytes = final_response.encode();
+//        let mut input = bytes.as_slice();
+//        let recovered_final_response = <WellformednessFinalResponse>::decode(&mut input).unwrap();
+//        assert_eq!(recovered_final_response, final_response);
+//    }
+//}
+//
+
+//use cryptography_core::curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
+//use rand_core::{CryptoRng, RngCore};
+//
+//type ZKPChallenge = Scalar;
+//
+//pub struct WellformednessInitialMessage {
+//    a: RistrettoPoint,
+//    generators: Vec<RistrettoPoint>,
+//    statement: RistrettoPoint,
+//}
+//
+//pub struct WellformednessFinalResponse {
+//    s: Vec<Scalar>,
+//}
+//
+//pub struct WellformednessProver {
+//    /// The randomness generate in the first round.
+//    rands: Vec<Scalar>,
+//    secrets: Vec<Scalar>,
+//    initial_message: WellformednessInitialMessage,
+//}
+//
+//impl WellformednessProver {
+//    pub fn new<T: RngCore + CryptoRng>(
+//        statement: RistrettoPoint,
+//        secrets: Vec<Scalar>,
+//        generators: Vec<RistrettoPoint>,
+//        rng: &mut T,
+//    ) -> Self {
+//        let rands: Vec<Scalar> = vec![0; generators.len()]
+//            .into_iter()
+//            .map(|_| Scalar::random(rng))
+//            .collect();
+//        let a = generators
+//            .clone()
+//            .into_iter()
+//            .zip(&rands)
+//            .map(|(gen, rand)| gen * rand)
+//            .fold_first(|v1, v2| v1 + v2)
+//            .unwrap();
+//
+//        Self {
+//            rands,
+//            secrets,
+//            initial_message: WellformednessInitialMessage {
+//                a,
+//                generators: generators.clone(),
+//                statement,
+//            },
+//        }
+//    }
+//
+//    pub fn apply_challenge(&self, c: ZKPChallenge) -> WellformednessFinalResponse {
+//        let s = (&self.rands)
+//            .into_iter()
+//            .zip(&self.secrets)
+//            .map(|(rand, secret)| rand + c * secret)
+//            .collect();
+//
+//        WellformednessFinalResponse { s }
+//    }
+//}
+//
+//pub fn verify(
+//    initial_message: WellformednessInitialMessage,
+//    final_response: WellformednessFinalResponse,
+//    c: ZKPChallenge,
+//) -> bool {
+//    let lhs = initial_message
+//        .generators
+//        .into_iter()
+//        .zip(final_response.s)
+//        .map(|(gen, s)| gen * s)
+//        .fold_first(|v1, v2| v1 + v2)
+//        .unwrap();
+//    let rhs = initial_message.a + initial_message.statement * c;
+//
+//    lhs == rhs
+//}

--- a/private-identity-audit/src/proofs.rs
+++ b/private-identity-audit/src/proofs.rs
@@ -93,8 +93,8 @@ pub fn verify(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{prover::generate_blinding_factor, InvestorID};
-    use confidential_identity::pedersen_commitments::PedersenGenerators;
+    use crate::prover::generate_blinding_factor;
+    use confidential_identity::{pedersen_commitments::PedersenGenerators, CddClaimData};
     use cryptography_core::curve25519_dalek::traits::MultiscalarMul;
     use rand::{rngs::StdRng, SeedableRng};
 
@@ -132,12 +132,17 @@ mod tests {
     fn test_zkp_cdd_id() {
         let mut rng = StdRng::from_seed([42u8; 32]);
         let pg = PedersenGenerators::default();
-        let investor = InvestorID {
-            uid: Scalar::random(&mut rng),
-            did: Scalar::random(&mut rng),
+        let claim = CddClaimData {
+            investor_unique_id: Scalar::random(&mut rng),
+            investor_did: Scalar::random(&mut rng),
         };
-        let blinding_factor = generate_blinding_factor(investor.did, investor.uid);
-        let secrets = [investor.did, investor.uid, blinding_factor];
+        let blinding_factor =
+            generate_blinding_factor(claim.investor_did, claim.investor_unique_id);
+        let secrets = [
+            claim.investor_did,
+            claim.investor_unique_id,
+            blinding_factor,
+        ];
         let cdd_id = pg.commit(&secrets);
         let r = Scalar::random(&mut rng);
         let statement = cdd_id * r;

--- a/private-identity-audit/src/proofs.rs
+++ b/private-identity-audit/src/proofs.rs
@@ -13,380 +13,110 @@
 //!   4. V: H^s1 * F^s2 == A * q^c
 //!
 
-use cryptography_core::{
-    asset_proofs::{
-        encryption_proofs::{
-            AssetProofProver, AssetProofProverAwaitingChallenge, AssetProofVerifier, ZKPChallenge,
-            ZKProofResponse,
-        },
-        transcript::{TranscriptProtocol, UpdateTranscript},
-    },
-    curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar},
-    errors::{ErrorKind as CoreErrorKind, Fallible as CoreFallible},
-};
-use merlin::{Transcript, TranscriptRng};
+use cryptography_core::curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
 use rand_core::{CryptoRng, RngCore};
 
-/// The domain label for the wellformedness proof.
-pub const WELLFORMEDNESS_PROOF_FINAL_RESPONSE_LABEL: &[u8] =
-    b"PIAL_PolymathWellformednessFinalResponse";
-/// The domain label for the challenge.
-pub const WELLFORMEDNESS_PROOF_CHALLENGE_LABEL: &[u8] =
-    b"PIAL_PolymathWellformednessProofChallenge";
+type Challenge = Scalar;
 
-pub struct WellformednessInitialMessage {
+#[derive(Clone)]
+pub struct InitialMessage {
     a: RistrettoPoint,
-}
-
-pub struct WellformednessFinalResponse {
-    s: Vec<Scalar>,
-}
-
-impl UpdateTranscript for WellformednessInitialMessage {
-    fn update_transcript(&self, transcript: &mut Transcript) -> CoreFallible<()> {
-        transcript.append_domain_separator(WELLFORMEDNESS_PROOF_CHALLENGE_LABEL);
-        transcript.append_validated_point(b"A", &self.a.compress())?;
-        Ok(())
-    }
-}
-
-/// Holds the non-interactive proofs of wellformedness, equivalent of L_enc of the MERCAT paper.
-pub type WellformednessProof =
-    ZKProofResponse<WellformednessInitialMessage, WellformednessFinalResponse>;
-
-#[derive(Clone, Debug)]
-pub struct WellformednessProver {
-    /// The secret commitment witness.
-    secrets: Vec<Scalar>,
-    /// The randomness generate in the first round.
-    rands: Vec<Scalar>,
+    generators: Vec<RistrettoPoint>,
 }
 
 #[derive(Clone)]
-pub struct WellformednessProverAwaitingChallenge<'a> {
-    /// The secret commitment witness.
-    pub secrets: Vec<Scalar>,
-
-    /// The Pedersen generators.
-    pub generators: &'a Vec<RistrettoPoint>,
+pub struct FinalResponse {
+    s: Vec<Scalar>,
 }
 
-impl<'a> AssetProofProverAwaitingChallenge for WellformednessProverAwaitingChallenge<'a> {
-    type ZKInitialMessage = WellformednessInitialMessage;
-    type ZKFinalResponse = WellformednessFinalResponse;
-    type ZKProver = WellformednessProver;
+pub struct Secrets {
+    rands: Vec<Scalar>,
+    secrets: Vec<Scalar>,
+}
 
-    fn create_transcript_rng<T: RngCore + CryptoRng>(
-        &self,
-        rng: &mut T,
-        transcript: &Transcript,
-    ) -> TranscriptRng {
-        (&self.secrets)
-            .into_iter()
-            .fold(transcript.build_rng(), |transcript_rng, secret| {
-                transcript_rng.rekey_with_witness_bytes(b"secret_value", secret.as_bytes())
-            })
-            .finalize(rng)
+pub fn generate_initial_message<T: RngCore + CryptoRng>(
+    secrets: Vec<Scalar>,
+    generators: Vec<RistrettoPoint>,
+    rng: &mut T,
+) -> (Secrets, InitialMessage) {
+    let rands: Vec<Scalar> = vec![0; generators.len()]
+        .into_iter()
+        .map(|_| Scalar::random(rng))
+        .collect();
+    let a = generators
+        .clone()
+        .into_iter()
+        .zip(&rands)
+        .map(|(gen, rand)| gen * rand)
+        .fold_first(|v1, v2| v1 + v2)
+        .unwrap();
+
+    (
+        Secrets { rands, secrets },
+        InitialMessage {
+            a,
+            generators: generators.clone(),
+        },
+    )
+}
+
+pub fn apply_challenge(prover_secrets: Secrets, c: Challenge) -> FinalResponse {
+    let s = (&prover_secrets.rands)
+        .into_iter()
+        .zip(&prover_secrets.secrets)
+        .map(|(rand, secret)| rand + c * secret)
+        .collect();
+
+    FinalResponse { s }
+}
+
+pub fn verify(
+    initial_message: InitialMessage,
+    final_response: FinalResponse,
+    statement: RistrettoPoint,
+    c: Challenge,
+) -> bool {
+    let lhs = initial_message
+        .generators
+        .into_iter()
+        .zip(final_response.s)
+        .map(|(gen, s)| gen * s)
+        .fold_first(|v1, v2| v1 + v2)
+        .unwrap(); // TODO
+    let rhs = initial_message.a + statement * c;
+
+    lhs == rhs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn test_zkp_proof() {
+        let mut rng = StdRng::from_seed([42u8; 32]);
+        let generators = vec![RistrettoPoint::random(&mut rng)];
+        let secrets = vec![Scalar::random(&mut rng)];
+        let statement = generators[0] * secrets[0];
+
+        let (prover_secrets, initial_message) =
+            generate_initial_message(secrets, generators, &mut rng);
+
+        let c = Scalar::random(&mut rng);
+        let final_response = apply_challenge(prover_secrets, c);
+
+        // Positive test
+        assert!(verify(
+            initial_message.clone(),
+            final_response.clone(),
+            statement,
+            c
+        ));
+
+        // Negative test
+        let statement = RistrettoPoint::random(&mut rng) * Scalar::random(&mut rng);
+        let is_valid = verify(initial_message, final_response, statement, c);
+        assert!(!is_valid);
     }
-
-    fn generate_initial_message(
-        &self,
-        rng: &mut TranscriptRng,
-    ) -> (Self::ZKProver, Self::ZKInitialMessage) {
-        let rands: Vec<Scalar> = vec![0; self.generators.len()]
-            .into_iter()
-            .map(|_| Scalar::random(rng))
-            .collect();
-        let a = self
-            .generators
-            .clone()
-            .into_iter()
-            .zip(&rands)
-            .map(|(gen, rand)| gen * rand)
-            .fold_first(|v1, v2| v1 + v2)
-            .unwrap();
-        (
-            WellformednessProver {
-                secrets: self.secrets.clone(),
-                rands,
-            },
-            WellformednessInitialMessage { a },
-        )
-    }
 }
-
-impl AssetProofProver<WellformednessFinalResponse> for WellformednessProver {
-    fn apply_challenge(&self, c: &ZKPChallenge) -> WellformednessFinalResponse {
-        let s = (&self.rands)
-            .into_iter()
-            .zip(&self.secrets)
-            .map(|(rand, secret)| rand + c.x() * secret)
-            .collect();
-        WellformednessFinalResponse { s }
-    }
-}
-
-#[derive(Copy, Clone)]
-pub struct WellformednessVerifier<'a> {
-    pub statement: RistrettoPoint,
-    pub generators: &'a Vec<RistrettoPoint>,
-}
-
-impl<'a> AssetProofVerifier for WellformednessVerifier<'a> {
-    type ZKInitialMessage = WellformednessInitialMessage;
-    type ZKFinalResponse = WellformednessFinalResponse;
-
-    fn verify(
-        &self,
-        challenge: &ZKPChallenge,
-        initial_message: &Self::ZKInitialMessage,
-        response: &Self::ZKFinalResponse,
-    ) -> CoreFallible<()> {
-        let lhs = self
-            .generators
-            .into_iter()
-            .zip(&response.s)
-            .map(|(gen, s)| gen * s)
-            .fold_first(|v1, v2| v1 + v2)
-            .ok_or(CoreErrorKind::WellformednessFinalResponseVerificationError { check: 1 })?;
-        let rhs = initial_message.a + self.statement * challenge.x();
-
-        // TODO replace with ErrorKind and ensure
-        assert_eq!(lhs, rhs);
-
-        Ok(())
-    }
-}
-
-//#[cfg(test)]
-//mod tests {
-//    extern crate wasm_bindgen_test;
-//    use super::*;
-//    use crate::asset_proofs::encryption_proofs::{
-//        single_property_prover, single_property_verifier,
-//    };
-//    use crate::asset_proofs::*;
-//    use rand::{rngs::StdRng, SeedableRng};
-//    use sp_std::prelude::*;
-//    use wasm_bindgen_test::*;
-//
-//    const SEED_1: [u8; 32] = [42u8; 32];
-//
-//    #[test]
-//    #[wasm_bindgen_test]
-//    fn test_wellformedness_proof() {
-//        let gens = PedersenGens::default();
-//        let mut rng = StdRng::from_seed(SEED_1);
-//        let secret_value = 42u32;
-//
-//        let elg_secret = ElgamalSecretKey::new(Scalar::random(&mut rng));
-//        let pub_key = elg_secret.get_public_key();
-//        let (w, cipher) = pub_key.encrypt_value(secret_value.into(), &mut rng);
-//
-//        let prover = WellformednessProverAwaitingChallenge {
-//            pub_key,
-//            w: w.clone(),
-//            pc_gens: &gens,
-//        };
-//        let verifier = WellformednessVerifier {
-//            pub_key,
-//            cipher,
-//            pc_gens: &gens,
-//        };
-//        let mut dealer_transcript = Transcript::new(WELLFORMEDNESS_PROOF_FINAL_RESPONSE_LABEL);
-//
-//        // ------------------------------- Interactive case
-//        // Positive tests
-//        // 1st round
-//        let mut transcript_rng = prover.create_transcript_rng(&mut rng, &dealer_transcript);
-//        let (prover, initial_message) = prover.generate_initial_message(&mut transcript_rng);
-//
-//        // 2nd round
-//        initial_message
-//            .update_transcript(&mut dealer_transcript)
-//            .unwrap();
-//        let challenge = dealer_transcript
-//            .scalar_challenge(WELLFORMEDNESS_PROOF_CHALLENGE_LABEL)
-//            .unwrap();
-//
-//        // 3rd round
-//        let final_response = prover.apply_challenge(&challenge);
-//
-//        // 4th round
-//        // in the interactive case, verifier is the dealer and therefore, the challenge is saved
-//        // on the verifier side and passed to this function.
-//        let result = verifier.verify(&challenge, &initial_message, &final_response);
-//        assert!(result.is_ok());
-//
-//        // Negative tests
-//        let bad_initial_message = WellformednessInitialMessage::default();
-//        let result = verifier.verify(&challenge, &bad_initial_message, &final_response);
-//        assert_err!(
-//            result,
-//            ErrorKind::WellformednessFinalResponseVerificationError { check: 1 }
-//        );
-//
-//        let bad_final_response = WellformednessFinalResponse {
-//            z1: Scalar::default(),
-//            z2: Scalar::default(),
-//        };
-//        let result = verifier.verify(&challenge, &initial_message, &bad_final_response);
-//        assert_err!(
-//            result,
-//            ErrorKind::WellformednessFinalResponseVerificationError { check: 1 }
-//        );
-//
-//        // ------------------------------- Non-interactive case
-//        let prover = WellformednessProverAwaitingChallenge {
-//            pub_key,
-//            w: w,
-//            pc_gens: &gens,
-//        };
-//        let verifier = WellformednessVerifier {
-//            pub_key,
-//            cipher,
-//            pc_gens: &gens,
-//        };
-//
-//        // 1st to 3rd rounds
-//        let (initial_message, final_response) = single_property_prover::<
-//            StdRng,
-//            WellformednessProverAwaitingChallenge,
-//        >(prover, &mut rng)
-//        .unwrap();
-//
-//        // Positive test
-//        assert!(
-//            // 4th round
-//            single_property_verifier(&verifier, (initial_message, final_response)).is_ok()
-//        );
-//
-//        // Negative tests
-//        let bad_initial_message = WellformednessInitialMessage::default();
-//        assert_err!(
-//            // 4th round
-//            single_property_verifier(&verifier, (bad_initial_message, final_response)),
-//            ErrorKind::WellformednessFinalResponseVerificationError { check: 1 }
-//        );
-//
-//        assert_err!(
-//            // 4th round
-//            single_property_verifier(&verifier, (initial_message, bad_final_response)),
-//            ErrorKind::WellformednessFinalResponseVerificationError { check: 1 }
-//        );
-//    }
-//
-//    #[test]
-//    #[wasm_bindgen_test]
-//    fn serialize_deserialize_proof() {
-//        let mut rng = StdRng::from_seed(SEED_1);
-//        let secret_value = 42u32;
-//        let rand_blind = Scalar::random(&mut rng);
-//        let gens = PedersenGens::default();
-//        let w = CommitmentWitness::new(secret_value.into(), rand_blind);
-//        let elg_secret = ElgamalSecretKey::new(Scalar::random(&mut rng));
-//        let pub_key = elg_secret.get_public_key();
-//
-//        let prover = WellformednessProverAwaitingChallenge {
-//            pub_key,
-//            w: w,
-//            pc_gens: &gens,
-//        };
-//        let (initial_message, final_response) = encryption_proofs::single_property_prover::<
-//            StdRng,
-//            WellformednessProverAwaitingChallenge,
-//        >(prover, &mut rng)
-//        .unwrap();
-//
-//        let bytes = initial_message.encode();
-//        let mut input = bytes.as_slice();
-//        let recovered_initial_message = <WellformednessInitialMessage>::decode(&mut input).unwrap();
-//        assert_eq!(recovered_initial_message, initial_message);
-//
-//        let bytes = final_response.encode();
-//        let mut input = bytes.as_slice();
-//        let recovered_final_response = <WellformednessFinalResponse>::decode(&mut input).unwrap();
-//        assert_eq!(recovered_final_response, final_response);
-//    }
-//}
-//
-
-//use cryptography_core::curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
-//use rand_core::{CryptoRng, RngCore};
-//
-//type ZKPChallenge = Scalar;
-//
-//pub struct WellformednessInitialMessage {
-//    a: RistrettoPoint,
-//    generators: Vec<RistrettoPoint>,
-//    statement: RistrettoPoint,
-//}
-//
-//pub struct WellformednessFinalResponse {
-//    s: Vec<Scalar>,
-//}
-//
-//pub struct WellformednessProver {
-//    /// The randomness generate in the first round.
-//    rands: Vec<Scalar>,
-//    secrets: Vec<Scalar>,
-//    initial_message: WellformednessInitialMessage,
-//}
-//
-//impl WellformednessProver {
-//    pub fn new<T: RngCore + CryptoRng>(
-//        statement: RistrettoPoint,
-//        secrets: Vec<Scalar>,
-//        generators: Vec<RistrettoPoint>,
-//        rng: &mut T,
-//    ) -> Self {
-//        let rands: Vec<Scalar> = vec![0; generators.len()]
-//            .into_iter()
-//            .map(|_| Scalar::random(rng))
-//            .collect();
-//        let a = generators
-//            .clone()
-//            .into_iter()
-//            .zip(&rands)
-//            .map(|(gen, rand)| gen * rand)
-//            .fold_first(|v1, v2| v1 + v2)
-//            .unwrap();
-//
-//        Self {
-//            rands,
-//            secrets,
-//            initial_message: WellformednessInitialMessage {
-//                a,
-//                generators: generators.clone(),
-//                statement,
-//            },
-//        }
-//    }
-//
-//    pub fn apply_challenge(&self, c: ZKPChallenge) -> WellformednessFinalResponse {
-//        let s = (&self.rands)
-//            .into_iter()
-//            .zip(&self.secrets)
-//            .map(|(rand, secret)| rand + c * secret)
-//            .collect();
-//
-//        WellformednessFinalResponse { s }
-//    }
-//}
-//
-//pub fn verify(
-//    initial_message: WellformednessInitialMessage,
-//    final_response: WellformednessFinalResponse,
-//    c: ZKPChallenge,
-//) -> bool {
-//    let lhs = initial_message
-//        .generators
-//        .into_iter()
-//        .zip(final_response.s)
-//        .map(|(gen, s)| gen * s)
-//        .fold_first(|v1, v2| v1 + v2)
-//        .unwrap();
-//    let rhs = initial_message.a + initial_message.statement * c;
-//
-//    lhs == rhs
-//}

--- a/private-identity-audit/src/proofs.rs
+++ b/private-identity-audit/src/proofs.rs
@@ -1,3 +1,5 @@
+//! Provides interactive ZKP for statements of muliple base.
+//!
 //! Statement: q=G^x
 //! ZKP(q, G):
 //!   1. P -> V: A = G^r
@@ -13,10 +15,9 @@
 //!   4. V: H^s1 * F^s2 == A * q^c
 //!
 
+use crate::Challenge;
 use cryptography_core::curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
 use rand_core::{CryptoRng, RngCore};
-
-type Challenge = Scalar;
 
 #[derive(Clone)]
 pub struct InitialMessage {

--- a/private-identity-audit/src/prover.rs
+++ b/private-identity-audit/src/prover.rs
@@ -3,85 +3,103 @@
 //! The goal is to prove the following statements.
 //! - a = C^r -> ZKP(a; C)
 //! - b = h^{y*r} * f^{z*r} -> ZKP(b; h, f)
-//! - a/b = g^r -> ZKP(a/b; g)
+//! - a/b = g^{x*r} -> ZKP(a/b; g)
 
 use crate::{
-    errors::Fallible, proofs::WellformednessProverAwaitingChallenge, EncryptedUIDs, InvestorID,
-    Proof, ProofGenerator,
+    errors::Fallible,
+    proofs::{apply_challenge, generate_initial_message},
+    ChallengeResponder, EncryptedUIDs, InvestorID, ProofGenerator, Proofs, ProverFinalResponse,
+    ProverSecrets,
 };
 use confidential_identity::pedersen_commitments::PedersenGenerators;
-use cryptography_core::{
-    asset_proofs::encryption_proofs::single_property_prover,
-    curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar},
-};
+use cryptography_core::curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
 use rand::seq::SliceRandom;
 use rand_core::{CryptoRng, RngCore};
 use sha3::{Digest, Sha3_512};
 
-pub struct Prover;
+pub struct InitialProver;
+pub struct FinalProver;
 
 /// Modified version of `generate_pedersen_commit` function of Confidential Identity Library.
-fn generate_bliding_factor(did: Scalar, uid: Scalar) -> Scalar {
+pub fn generate_bliding_factor(did: Scalar, uid: Scalar) -> Scalar {
     let hash = Sha3_512::default()
         .chain(did.as_bytes())
         .chain(uid.as_bytes());
     Scalar::from_hash(hash)
 }
 
-impl ProofGenerator for Prover {
+impl ProofGenerator for InitialProver {
     fn generate_membership_proof<T: RngCore + CryptoRng>(
         investor: InvestorID,
-        encrypted_uids: EncryptedUIDs,
         rng: &mut T,
-    ) -> Fallible<Proof> {
+    ) -> Fallible<(ProverSecrets, Proofs, RistrettoPoint)> {
         let pg = PedersenGenerators::default();
         let blinding_factor = generate_bliding_factor(investor.did, investor.uid);
         let secrets = [investor.did, investor.uid, blinding_factor];
         let cdd_id = pg.commit(&secrets);
-        //let second_half = pg.generators[1] * investor.uid + pg.generators[2] * blinding_factor;
+        let cdd_id_second_half =
+            pg.generators[1] * investor.uid + pg.generators[2] * blinding_factor;
 
         let r = Scalar::random(rng);
-        //let statement1 = cdd_id * r;
-        //let statement2 = second_half * r;
-        //let statement3 = statement1 - statement2;
 
-        let _proof1 = single_property_prover(
-            WellformednessProverAwaitingChallenge {
-                secrets: vec![r],
-                generators: &vec![cdd_id],
-            },
+        // Corresponds to proving a = C^r, where C is cdd_id
+        let (cdd_id_proof_secrets, cdd_id_proof) =
+            generate_initial_message(vec![r], vec![cdd_id], rng);
+
+        // Corresponds to proving b = h^{y*r} * f^{z*r}
+        let (cdd_id_second_half_proof_secrets, cdd_id_second_half_proof) = generate_initial_message(
+            [investor.did * r, blinding_factor * r].to_vec(),
+            vec![pg.generators[1], pg.generators[2]],
             rng,
-        )
-        .unwrap();
+        );
 
-        let _proof2 = single_property_prover(
-            WellformednessProverAwaitingChallenge {
-                secrets: [secrets[1] * r, secrets[2] * r].to_vec(),
-                generators: &vec![pg.generators[1], pg.generators[2]],
+        // Corresponds to proving a/b = g^{x*r}, where a/b
+        let (uid_commitment_proof_secrets, uid_commitment_proof) =
+            generate_initial_message(vec![investor.uid * r], vec![pg.generators[0]], rng);
+
+        Ok((
+            ProverSecrets {
+                cdd_id_proof_secrets,
+                cdd_id_second_half_proof_secrets,
+                uid_commitment_proof_secrets,
+                rand: r,
             },
-            rng,
-        )
-        .unwrap();
-
-        let _proof3 = single_property_prover(
-            WellformednessProverAwaitingChallenge {
-                secrets: vec![r],
-                generators: &vec![pg.generators[0]],
+            Proofs {
+                cdd_id_proof,
+                cdd_id_second_half_proof,
+                uid_commitment_proof,
             },
-            rng,
-        )
-        .unwrap();
+            cdd_id_second_half,
+        ))
+    }
+}
 
-        let mut recommit: Vec<RistrettoPoint> =
+impl ChallengeResponder for FinalProver {
+    fn generate_challenge_response<T: RngCore + CryptoRng>(
+        secrets: ProverSecrets,
+        encrypted_uids: EncryptedUIDs,
+        challenge: Scalar,
+        rng: &mut T,
+    ) -> Fallible<(ProverFinalResponse, EncryptedUIDs)> {
+        let r = secrets.rand;
+        let mut recommitted_uids: Vec<RistrettoPoint> =
             encrypted_uids.into_iter().map(|e_uid| e_uid * r).collect();
-        recommit.shuffle(rng);
+        recommitted_uids.shuffle(rng);
 
-        Ok(Proof {
-            //proof1,
-            //proof2,
-            //proof3,
-            //recommit,
-        })
+        let cdd_id_proof_response = apply_challenge(secrets.cdd_id_proof_secrets, challenge);
+        let cdd_id_second_half_proof_response =
+            apply_challenge(secrets.cdd_id_second_half_proof_secrets, challenge);
+        let uid_commitment_proof_response =
+            apply_challenge(secrets.uid_commitment_proof_secrets, challenge);
+
+        Ok((
+            ProverFinalResponse {
+                cdd_id_proof_response,
+                cdd_id_second_half_proof_response,
+                uid_commitment_proof_response,
+            },
+            recommitted_uids,
+        ))
     }
 }
 

--- a/private-identity-audit/src/prover.rs
+++ b/private-identity-audit/src/prover.rs
@@ -1,0 +1,101 @@
+//! Given C = g^x * h^y * f^z
+//!
+//! The goal is to prove the following statements.
+//! - a = C^r -> ZKP(a; C)
+//! - b = h^{y*r} * f^{z*r} -> ZKP(b; h, f)
+//! - a/b = g^r -> ZKP(a/b; g)
+
+use crate::{
+    errors::Fallible, proofs::WellformednessProverAwaitingChallenge, EncryptedUIDs, InvestorID,
+    Proof, ProofGenerator,
+};
+use confidential_identity::pedersen_commitments::PedersenGenerators;
+use cryptography_core::{
+    asset_proofs::encryption_proofs::single_property_prover,
+    curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar},
+};
+use rand::seq::SliceRandom;
+use rand_core::{CryptoRng, RngCore};
+use sha3::{Digest, Sha3_512};
+
+pub struct Prover;
+
+/// Modified version of `generate_pedersen_commit` function of Confidential Identity Library.
+fn generate_bliding_factor(did: Scalar, uid: Scalar) -> Scalar {
+    let hash = Sha3_512::default()
+        .chain(did.as_bytes())
+        .chain(uid.as_bytes());
+    Scalar::from_hash(hash)
+}
+
+impl ProofGenerator for Prover {
+    fn generate_membership_proof<T: RngCore + CryptoRng>(
+        investor: InvestorID,
+        encrypted_uids: EncryptedUIDs,
+        rng: &mut T,
+    ) -> Fallible<Proof> {
+        let pg = PedersenGenerators::default();
+        let blinding_factor = generate_bliding_factor(investor.did, investor.uid);
+        let secrets = [investor.did, investor.uid, blinding_factor];
+        let cdd_id = pg.commit(&secrets);
+        //let second_half = pg.generators[1] * investor.uid + pg.generators[2] * blinding_factor;
+
+        let r = Scalar::random(rng);
+        //let statement1 = cdd_id * r;
+        //let statement2 = second_half * r;
+        //let statement3 = statement1 - statement2;
+
+        let _proof1 = single_property_prover(
+            WellformednessProverAwaitingChallenge {
+                secrets: vec![r],
+                generators: &vec![cdd_id],
+            },
+            rng,
+        )
+        .unwrap();
+
+        let _proof2 = single_property_prover(
+            WellformednessProverAwaitingChallenge {
+                secrets: [secrets[1] * r, secrets[2] * r].to_vec(),
+                generators: &vec![pg.generators[1], pg.generators[2]],
+            },
+            rng,
+        )
+        .unwrap();
+
+        let _proof3 = single_property_prover(
+            WellformednessProverAwaitingChallenge {
+                secrets: vec![r],
+                generators: &vec![pg.generators[0]],
+            },
+            rng,
+        )
+        .unwrap();
+
+        let mut recommit: Vec<RistrettoPoint> =
+            encrypted_uids.into_iter().map(|e_uid| e_uid * r).collect();
+        recommit.shuffle(rng);
+
+        Ok(Proof {
+            //proof1,
+            //proof2,
+            //proof3,
+            //recommit,
+        })
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// -                                            Tests                                             -
+// ------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    //use crate::{PrivateSetGenerator, SET_SIZE_ANONYMITY_PARAM};
+    //use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn test_generate_proof() {
+        //let mut rng = StdRng::from_seed([10u8; 32]);
+    }
+}

--- a/private-identity-audit/src/prover.rs
+++ b/private-identity-audit/src/prover.rs
@@ -48,21 +48,22 @@ impl ProofGenerator for InitialProver {
         // Corresponds to proving a = C^r, where C is cdd_id. `a` is represented as
         // `committed_cdd_id`.
         let (cdd_id_proof_secrets, cdd_id_proof) =
-            generate_initial_message(vec![r], vec![cdd_id], rng);
+            generate_initial_message(vec![r], vec![cdd_id], rng)?;
         let committed_cdd_id = cdd_id * r;
 
         // Corresponds to proving b = h^{y*r} * f^{z*r}, b is represented as `commited_cdd_id_second_half`.
-        let (cdd_id_second_half_proof_secrets, cdd_id_second_half_proof) = generate_initial_message(
-            [investor.did * r, blinding_factor * r].to_vec(),
-            vec![pg.generators[1], pg.generators[2]],
-            rng,
-        );
+        let (cdd_id_second_half_proof_secrets, cdd_id_second_half_proof) =
+            generate_initial_message(
+                [investor.did * r, blinding_factor * r].to_vec(),
+                vec![pg.generators[1], pg.generators[2]],
+                rng,
+            )?;
         let commited_cdd_id_second_half =
             (pg.generators[1] * investor.did + pg.generators[2] * blinding_factor) * r;
 
         // Corresponds to proving a/b = g^{x*r}.
         let (uid_commitment_proof_secrets, uid_commitment_proof) =
-            generate_initial_message(vec![investor.uid * r], vec![pg.generators[0]], rng);
+            generate_initial_message(vec![investor.uid * r], vec![pg.generators[0]], rng)?;
 
         Ok((
             ProverSecrets {

--- a/private-identity-audit/src/prover.rs
+++ b/private-identity-audit/src/prover.rs
@@ -8,8 +8,8 @@
 use crate::{
     errors::Fallible,
     proofs::{apply_challenge, generate_initial_message},
-    ChallengeResponder, EncryptedUIDs, InvestorID, ProofGenerator, Proofs, ProverFinalResponse,
-    ProverSecrets,
+    ChallengeResponder, CommittedCDDID, CommittedSecondHalfCDDID, EncryptedUIDs, InvestorID,
+    ProofGenerator, Proofs, ProverFinalResponse, ProverSecrets,
 };
 use confidential_identity::pedersen_commitments::PedersenGenerators;
 use cryptography_core::curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
@@ -29,10 +29,15 @@ pub fn generate_bliding_factor(uid: Scalar, did: Scalar) -> Scalar {
 }
 
 impl ProofGenerator for InitialProver {
-    fn generate_membership_proof<T: RngCore + CryptoRng>(
+    fn generate_initial_proofs<T: RngCore + CryptoRng>(
         investor: InvestorID,
         rng: &mut T,
-    ) -> Fallible<(ProverSecrets, Proofs, RistrettoPoint, RistrettoPoint)> {
+    ) -> Fallible<(
+        ProverSecrets,
+        Proofs,
+        CommittedCDDID,
+        CommittedSecondHalfCDDID,
+    )> {
         let pg = PedersenGenerators::default();
         let blinding_factor = generate_bliding_factor(investor.uid, investor.did);
         let secrets = [investor.uid, investor.did, blinding_factor];
@@ -103,20 +108,5 @@ impl ChallengeResponder for FinalProver {
             },
             recommitted_uids,
         ))
-    }
-}
-
-// ------------------------------------------------------------------------------------------------
-// -                                            Tests                                             -
-// ------------------------------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    //use crate::{PrivateSetGenerator, SET_SIZE_ANONYMITY_PARAM};
-    //use rand::{rngs::StdRng, SeedableRng};
-
-    #[test]
-    fn test_generate_proof() {
-        //let mut rng = StdRng::from_seed([10u8; 32]);
     }
 }

--- a/private-identity-audit/src/prover.rs
+++ b/private-identity-audit/src/prover.rs
@@ -21,10 +21,10 @@ pub struct InitialProver;
 pub struct FinalProver;
 
 /// Modified version of `generate_pedersen_commit` function of Confidential Identity Library.
-pub fn generate_bliding_factor(did: Scalar, uid: Scalar) -> Scalar {
+pub fn generate_bliding_factor(uid: Scalar, did: Scalar) -> Scalar {
     let hash = Sha3_512::default()
-        .chain(did.as_bytes())
-        .chain(uid.as_bytes());
+        .chain(uid.as_bytes())
+        .chain(did.as_bytes());
     Scalar::from_hash(hash)
 }
 

--- a/private-identity-audit/src/prover.rs
+++ b/private-identity-audit/src/prover.rs
@@ -34,7 +34,7 @@ impl ProofGenerator for InitialProver {
         rng: &mut T,
     ) -> Fallible<(ProverSecrets, Proofs, RistrettoPoint, RistrettoPoint)> {
         let pg = PedersenGenerators::default();
-        let blinding_factor = generate_bliding_factor(investor.did, investor.uid);
+        let blinding_factor = generate_bliding_factor(investor.uid, investor.did);
         let secrets = [investor.uid, investor.did, blinding_factor];
         let cdd_id = pg.commit(&secrets);
 

--- a/private-identity-audit/src/prover.rs
+++ b/private-identity-audit/src/prover.rs
@@ -140,8 +140,8 @@ mod tests {
 
         // Verifier shares one of its uids with the Prover.
         let claim = CddClaimData {
-            investor_did: private_uid_set[0],
-            investor_unique_id: Scalar::random(&mut rng),
+            investor_unique_id: private_uid_set[0],
+            investor_did: Scalar::random(&mut rng),
         };
 
         // Prover generates cdd_id and places it on the chain.

--- a/private-identity-audit/src/verifier.rs
+++ b/private-identity-audit/src/verifier.rs
@@ -1,0 +1,115 @@
+use crate::{
+    errors::{ErrorKind, Fallible},
+    EncryptedUIDs, PrivateSetGenerator, PrivateUIDs, SET_SIZE_ANONYMITY_PARAM,
+};
+use blake2::{Blake2b, Digest};
+use confidential_identity::pedersen_commitments::PedersenGenerators;
+use cryptography_core::curve25519_dalek::scalar::Scalar;
+use rand_core::{CryptoRng, RngCore};
+use uuid::{Builder, Uuid, Variant, Version};
+
+pub struct VerifierSetGenerator;
+
+impl PrivateSetGenerator for VerifierSetGenerator {
+    fn generate_encrypted_unique_ids<T: RngCore + CryptoRng>(
+        &self,
+        private_unique_identifiers: PrivateUIDs,
+        min_set_size: Option<usize>,
+        rng: &mut T,
+    ) -> Fallible<EncryptedUIDs> {
+        // Pad the input vector with randomly generated uuids.
+        let min_size = if let Some(overriden_size) = min_set_size {
+            overriden_size
+        } else {
+            SET_SIZE_ANONYMITY_PARAM
+        };
+        let padded_vec = if private_unique_identifiers.len() >= min_size {
+            private_unique_identifiers
+        } else {
+            let padding = gen_random_uuids(min_size - private_unique_identifiers.len(), rng);
+            [&private_unique_identifiers[..], &padding[..]].concat()
+        };
+
+        // Commit to each element.
+        let pg = PedersenGenerators::default();
+        Ok(padded_vec
+            .into_iter()
+            .map(|uid| uuid_to_scalar(uid))
+            .map(|scalar_uid| Scalar::random(rng) * scalar_uid)
+            .map(|blinded_uid| pg.generators[0] * blinded_uid)
+            .collect())
+    }
+}
+
+/// Modified version of `slice_to_scalar` of Confidential Identity Library.
+/// Creates a scalar from a UUID.
+fn uuid_to_scalar(uuid: Uuid) -> Scalar {
+    let mut hash = [0u8; 64];
+    hash.copy_from_slice(Blake2b::digest(uuid.as_bytes()).as_slice());
+    Scalar::from_bytes_mod_order_wide(&hash)
+}
+
+fn gen_random_uuids<T: RngCore + CryptoRng>(count: usize, rng: &mut T) -> Vec<Uuid> {
+    vec![0; count]
+        .into_iter()
+        .map(|_| {
+            let mut random_bytes: [u8; 16] = [0; 16];
+            rng.fill_bytes(&mut random_bytes);
+            let rand_uuid = Builder::from_bytes(random_bytes)
+                .set_variant(Variant::RFC4122)
+                .set_version(Version::Random)
+                .build();
+            rand_uuid
+        })
+        .collect()
+}
+
+// ------------------------------------------------------------------------------------------------
+// -                                            Tests                                             -
+// ------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        verifier::{gen_random_uuids, VerifierSetGenerator},
+        PrivateSetGenerator, SET_SIZE_ANONYMITY_PARAM,
+    };
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn test_verifier_set_gen_length() {
+        let mut rng = StdRng::from_seed([10u8; 32]);
+        let input_len = 10;
+
+        // Test original anonoymity param.
+        let encrytped_uids = VerifierSetGenerator
+            .generate_encrypted_unique_ids(gen_random_uuids(input_len, &mut rng), None, &mut rng)
+            .expect("Success");
+
+        assert_eq!(encrytped_uids.len(), SET_SIZE_ANONYMITY_PARAM);
+
+        // Test overridden anonoymity param.
+        let different_annonymity_size = 20;
+        let encrytped_uids = VerifierSetGenerator
+            .generate_encrypted_unique_ids(
+                gen_random_uuids(input_len, &mut rng),
+                Some(different_annonymity_size),
+                &mut rng,
+            )
+            .expect("Success");
+
+        assert_eq!(encrytped_uids.len(), different_annonymity_size);
+
+        // Test no padding.
+        let different_annonymity_size = 5;
+        let encrytped_uids = VerifierSetGenerator
+            .generate_encrypted_unique_ids(
+                gen_random_uuids(input_len, &mut rng),
+                Some(different_annonymity_size),
+                &mut rng,
+            )
+            .expect("Success");
+
+        assert_eq!(encrytped_uids.len(), input_len);
+    }
+}

--- a/private-identity-audit/src/verifier.rs
+++ b/private-identity-audit/src/verifier.rs
@@ -38,8 +38,7 @@ impl PrivateSetGenerator for VerifierSetGenerator {
         let mut commitments = padded_vec
             .into_iter()
             .map(|uid| uuid_to_scalar(uid))
-            .map(|scalar_uid| r * scalar_uid)
-            .map(|blinded_uid| pg.generators[0] * blinded_uid)
+            .map(|scalar_uid| pg.generators[0] * scalar_uid * r)
             .collect::<EncryptedUIDs>();
         commitments.shuffle(rng);
 

--- a/private-identity-audit/src/verifier.rs
+++ b/private-identity-audit/src/verifier.rs
@@ -54,23 +54,24 @@ impl ProofVerifier for Verifier {
         initial_message: Proofs,
         final_response: ProverFinalResponse,
         challenge: Scalar,
-        cdd_id: RistrettoPoint,
-        cdd_id_second_half: RistrettoPoint,
+        cdd_id: RistrettoPoint, // TODO: need to find a way of using this.
+        committed_cdd_id: RistrettoPoint,
+        committed_cdd_id_second_half: RistrettoPoint,
         verifier_secrets: VerifierSecrets,
         re_encrypted_uids: EncryptedUIDs,
     ) -> Fallible<()> {
-        let uid_commitment = cdd_id - cdd_id_second_half;
+        let uid_commitment = committed_cdd_id - committed_cdd_id_second_half;
 
         assert!(verify(
             initial_message.cdd_id_proof,
             final_response.cdd_id_proof_response,
-            cdd_id,
+            committed_cdd_id,
             challenge,
         )); // TODO
         assert!(verify(
             initial_message.cdd_id_second_half_proof,
             final_response.cdd_id_second_half_proof_response,
-            cdd_id_second_half,
+            committed_cdd_id_second_half,
             challenge,
         )); // TODO
         assert!(verify(

--- a/private-identity-audit/src/verifier.rs
+++ b/private-identity-audit/src/verifier.rs
@@ -60,6 +60,7 @@ impl ProofVerifier for Verifier {
         re_encrypted_uids: EncryptedUIDs,
     ) -> Fallible<()> {
         let uid_commitment = committed_cdd_id - committed_cdd_id_second_half;
+        assert_eq!(initial_message.cdd_id_proof.generators[0], cdd_id);
 
         assert!(verify(
             initial_message.cdd_id_proof,

--- a/private-identity-audit/src/verifier.rs
+++ b/private-identity-audit/src/verifier.rs
@@ -5,6 +5,7 @@ use crate::{
 use blake2::{Blake2b, Digest};
 use confidential_identity::pedersen_commitments::PedersenGenerators;
 use cryptography_core::curve25519_dalek::scalar::Scalar;
+use rand::seq::SliceRandom;
 use rand_core::{CryptoRng, RngCore};
 use uuid::{Builder, Uuid, Variant, Version};
 
@@ -32,12 +33,15 @@ impl PrivateSetGenerator for VerifierSetGenerator {
 
         // Commit to each element.
         let pg = PedersenGenerators::default();
-        Ok(padded_vec
+        let mut commitments = padded_vec
             .into_iter()
             .map(|uid| uuid_to_scalar(uid))
             .map(|scalar_uid| Scalar::random(rng) * scalar_uid)
             .map(|blinded_uid| pg.generators[0] * blinded_uid)
-            .collect())
+            .collect::<EncryptedUIDs>();
+        commitments.shuffle(rng);
+
+        Ok(commitments)
     }
 }
 

--- a/private-identity-audit/src/verifier.rs
+++ b/private-identity-audit/src/verifier.rs
@@ -1,8 +1,7 @@
 use crate::{
-    errors::{ErrorKind, Fallible},
-    EncryptedUIDs, PrivateSetGenerator, PrivateUIDs, SET_SIZE_ANONYMITY_PARAM,
+    errors::Fallible, uuid_to_scalar, EncryptedUIDs, PrivateSetGenerator, PrivateUIDs,
+    SET_SIZE_ANONYMITY_PARAM,
 };
-use blake2::{Blake2b, Digest};
 use confidential_identity::pedersen_commitments::PedersenGenerators;
 use cryptography_core::curve25519_dalek::scalar::Scalar;
 use rand::seq::SliceRandom;
@@ -43,14 +42,6 @@ impl PrivateSetGenerator for VerifierSetGenerator {
 
         Ok(commitments)
     }
-}
-
-/// Modified version of `slice_to_scalar` of Confidential Identity Library.
-/// Creates a scalar from a UUID.
-fn uuid_to_scalar(uuid: Uuid) -> Scalar {
-    let mut hash = [0u8; 64];
-    hash.copy_from_slice(Blake2b::digest(uuid.as_bytes()).as_slice());
-    Scalar::from_bytes_mod_order_wide(&hash)
 }
 
 fn gen_random_uuids<T: RngCore + CryptoRng>(count: usize, rng: &mut T) -> Vec<Uuid> {


### PR DESCRIPTION
This PR adds PIAL code.

To make reviewing this PR easier, at the moment this PR adds Confidential Identity as a dependency of PIAL. I'll change that in a later PR and refactor it such that both CIL and PIAL depend only on cryptography core.