### PR TITLE
WASM API for mercat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 	"mercat/cli/mediator",
 	"mercat/cli/validator",
 	"mercat/cli/interactive",
+	"mercat/wasm",
 	"confidential-identity",
 	"confidential-identity/ffi",
 	"confidential-identity/cli/scp",

--- a/mercat/wasm/Cargo.toml
+++ b/mercat/wasm/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "mercat-wasm"
+version = "0.1.0"
+authors = ["Polymath Inc"]
+description = "The wasm library for MERCAT."
+repository = "https://github.com/PolymathNetwork/cryptography"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+mercat = { path = ".." }
+rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
+rand_core = { version = "0.5", default-features = false}
+serde = { version = "1.0.105", features = ["derive"] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+serde_bytes = { version = "0.11", default-features = false, features = ["alloc"]}
+wasm-bindgen = "0.2"
+hex = { version = "0.4.2" }
+base64 = { version = "0.12.1" }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"]}
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-mutable-globals"]

--- a/mercat/wasm/Cargo.toml
+++ b/mercat/wasm/Cargo.toml
@@ -15,7 +15,6 @@ rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], d
 rand_core = { version = "0.5", default-features = false}
 serde = { version = "1.0.105", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-serde_bytes = { version = "0.11", default-features = false, features = ["alloc"]}
 wasm-bindgen = "0.2"
 hex = { version = "0.4.2" }
 base64 = { version = "0.12.1" }

--- a/mercat/wasm/Cargo.toml
+++ b/mercat/wasm/Cargo.toml
@@ -15,7 +15,7 @@ rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], d
 rand_core = { version = "0.5", default-features = false}
 serde = { version = "1.0.105", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-wasm-bindgen = "0.2"
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 hex = { version = "0.4.2" }
 base64 = { version = "0.12.1" }
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"]}

--- a/mercat/wasm/README.md
+++ b/mercat/wasm/README.md
@@ -1,0 +1,6 @@
+# WASM bindings for MERCAT Library
+
+
+This library provides WASM binding for MERCAT.
+
+To build this library, run `wasm-pack build --release`

--- a/mercat/wasm/src/lib.rs
+++ b/mercat/wasm/src/lib.rs
@@ -216,6 +216,7 @@ pub enum WasmError {
     Base64DecodingError,
     HexDecodingError,
     PlainTickerIdsError,
+    DecryptionError,
 }
 
 impl From<WasmError> for JsValue {
@@ -434,6 +435,31 @@ pub fn justify_transaction(
     Ok(JustifiedTransactionOutput {
         justified_tx: base64::encode(justified_tx.encode()),
     })
+}
+
+/// TODO
+///
+/// # Arguments
+/// * `todo`: todo
+///
+/// # Outputs
+/// * `todo`: todo
+///
+/// # Errors
+/// * todo
+#[wasm_bindgen]
+pub fn decrypt(encrypted_value: Base64, account: Account) -> Fallible<u32> {
+    let enc_balance = decode::<EncryptedAmount>(encrypted_value)?;
+    let account = account.to_mercat()?;
+
+    let decrypted_value = account
+        .secret
+        .enc_keys
+        .secret
+        .decrypt(&enc_balance)
+        .map_err(|_| WasmError::DecryptionError)?;
+
+    Ok(decrypted_value)
 }
 
 // ------------------------------------------------------------------------------------

--- a/mercat/wasm/src/lib.rs
+++ b/mercat/wasm/src/lib.rs
@@ -311,11 +311,11 @@ pub fn create_account(
 /// # Arguments
 ///
 /// # Outputs
-/// * `CreatMediatorAccountOutput`: Contains the public and secret mediator account.
+/// * `CreateMediatorAccountOutput`: Contains the public and secret mediator account.
 ///
 /// # Errors
 #[wasm_bindgen]
-pub fn create_mediator_account() -> CreatMediatorAccountOutput {
+pub fn create_mediator_account() -> CreateMediatorAccountOutput {
     let mut rng = OsRng;
 
     let mediator_elg_secret_key = ElgamalSecretKey::new(Scalar::random(&mut rng));
@@ -324,7 +324,7 @@ pub fn create_mediator_account() -> CreatMediatorAccountOutput {
         secret: mediator_elg_secret_key,
     };
 
-    CreatMediatorAccountOutput {
+    CreateMediatorAccountOutput {
         public_key: base64::encode(mediator_enc_key.public.encode()),
         secret_account: MediatorAccount {
             secret: base64::encode(
@@ -453,7 +453,7 @@ pub fn finalize_transaction(
 /// # Arguments
 /// * `finalized_tx`: The finalized transaction proof. Can be obtained from the chain.
 /// * `mediator_account`: The secret portion of the mediator's account. Can be obtained from
-///                       `CreatMediatorAccountOutput.secret_account`.
+///                       `CreateMediatorAccountOutput.secret_account`.
 /// * `sender_public_account`: Sender's public account. Can be obtained from the chain.
 /// * `sender_encrypted_pending_balance`: Sender's encrypted pending balance.
 ///                                       Can be obtained from the chain.

--- a/mercat/wasm/src/lib.rs
+++ b/mercat/wasm/src/lib.rs
@@ -30,9 +30,42 @@ pub struct CreatAccountOutput {
 }
 
 #[wasm_bindgen]
+impl CreatAccountOutput {
+    #[wasm_bindgen(getter)]
+    pub fn secret_account(&self) -> Base64 {
+        self.secret_account.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn account_id(&self) -> Base64 {
+        self.account_id.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn account_tx(&self) -> Base64 {
+        self.account_tx.clone()
+    }
+}
+
+#[wasm_bindgen]
 pub struct CreatMediatorAccountOutput {
     secret_account: MediatorAccount,
     public_account: Base64,
+}
+
+#[wasm_bindgen]
+impl CreatMediatorAccountOutput {
+    #[wasm_bindgen(getter)]
+    pub fn secret_account(&self) -> MediatorAccount {
+        MediatorAccount {
+            secret: self.secret_account.secret.clone(),
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn public_account(&self) -> Base64 {
+        self.public_account.clone()
+    }
 }
 
 #[wasm_bindgen]
@@ -41,8 +74,24 @@ pub struct CreateTransactionOutput {
 }
 
 #[wasm_bindgen]
+impl CreateTransactionOutput {
+    #[wasm_bindgen(getter)]
+    pub fn init_tx(&self) -> Base64 {
+        self.init_tx.clone()
+    }
+}
+
+#[wasm_bindgen]
 pub struct FinalizedTransactionOutput {
     finalized_tx: Base64,
+}
+
+#[wasm_bindgen]
+impl FinalizedTransactionOutput {
+    #[wasm_bindgen(getter)]
+    pub fn finalized_tx(&self) -> Base64 {
+        self.finalized_tx.clone()
+    }
 }
 
 #[wasm_bindgen]
@@ -51,8 +100,24 @@ pub struct JustifiedTransactionOutput {
 }
 
 #[wasm_bindgen]
+impl JustifiedTransactionOutput {
+    #[wasm_bindgen(getter)]
+    pub fn justified_tx(&self) -> Base64 {
+        self.justified_tx.clone()
+    }
+}
+
+#[wasm_bindgen]
 pub struct MintAssetOutput {
     asset_tx: Base64,
+}
+
+#[wasm_bindgen]
+impl MintAssetOutput {
+    #[wasm_bindgen(getter)]
+    pub fn asset_tx(&self) -> Base64 {
+        self.asset_tx.clone()
+    }
 }
 
 #[wasm_bindgen]

--- a/mercat/wasm/src/lib.rs
+++ b/mercat/wasm/src/lib.rs
@@ -1,0 +1,324 @@
+use base64;
+use codec::{Decode, Encode};
+use mercat::{
+    account::{convert_asset_ids, AccountCreator},
+    asset::AssetIssuer,
+    cryptography_core::{
+        asset_proofs::{CipherText, CommitmentWitness, ElgamalPublicKey, ElgamalSecretKey},
+        curve25519_dalek::scalar::Scalar,
+        errors::Error,
+        AssetId,
+    },
+    transaction::{CtxMediator, CtxReceiver, CtxSender},
+    Account as MercatAccount, AccountCreatorInitializer, AssetTransactionIssuer, EncryptionKeys,
+    FinalizedTransferTx, InitializedTransferTx, MediatorAccount, PubAccount as MercatPubAccount,
+    SecAccount, TransferTransactionMediator, TransferTransactionReceiver,
+    TransferTransactionSender,
+};
+use rand::{rngs::StdRng, SeedableRng};
+use rand_core::{OsRng, RngCore};
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+pub type PlainHex = String;
+
+pub type Base64 = String;
+
+#[wasm_bindgen]
+pub struct CreatAccountOutput {
+    secret_account: Base64,
+    account_id: Base64,
+    account_tx: Base64,
+}
+
+#[wasm_bindgen]
+pub struct CreatMediatorAccountOutput {
+    secret_account: Base64,
+    public_account: Base64,
+}
+
+#[wasm_bindgen]
+pub struct CreateTransactionOutput {
+    init_tx: Base64,
+}
+
+#[wasm_bindgen]
+pub struct FinalizedTransactionOutput {
+    finalized_tx: Base64,
+}
+
+#[wasm_bindgen]
+pub struct MintAssetOutput {
+    asset_tx: Base64,
+}
+
+#[wasm_bindgen]
+pub struct ValidAssetIds {
+    plain_hex_ids: Vec<PlainHex>,
+}
+
+#[wasm_bindgen]
+pub struct Account {
+    secret_account: Base64,
+    public_account: PubAccount,
+}
+
+#[wasm_bindgen]
+pub struct PubAccount {
+    account_id: Base64,
+    public_key: Base64,
+}
+
+impl PubAccount {
+    fn to_mercat(&self) -> MercatPubAccount {
+        let decoded = base64::decode(&self.public_key).unwrap();
+        let owner_enc_pub_key = ElgamalPublicKey::decode(&mut &decoded[..]).unwrap();
+
+        let decoded = base64::decode(&self.account_id).unwrap();
+        let enc_asset_id = CipherText::decode(&mut &decoded[..]).unwrap();
+
+        MercatPubAccount {
+            owner_enc_pub_key,
+            enc_asset_id,
+        }
+    }
+}
+
+impl Account {
+    fn to_mercat(&self) -> MercatAccount {
+        let decoded = base64::decode(&self.secret_account).unwrap();
+        let secret = SecAccount::decode(&mut &decoded[..]).unwrap();
+
+        MercatAccount {
+            secret,
+            public: self.public_account.to_mercat(),
+        }
+    }
+}
+
+/// TODO
+///
+/// # Arguments
+/// * `todo`: todo
+///
+/// # Outputs
+/// * `todo`: todo
+///
+/// # Errors
+/// * todo
+#[wasm_bindgen]
+pub fn create_account(
+    valid_ticker_ids: ValidAssetIds,
+    ticker_id: PlainHex,
+) -> Result<CreatAccountOutput, JsValue> {
+    let mut rng = OsRng;
+
+    let secret_account = create_secret_account(&mut rng, ticker_id.clone()).unwrap(); // TODO
+    let valid_asset_ids: Vec<AssetId> = valid_ticker_ids
+        .plain_hex_ids
+        .into_iter()
+        .map(|ticker_id| {
+            let mut asset_id = [0u8; 12];
+            let decoded = hex::decode(ticker_id).unwrap(); // TODO
+            asset_id[..decoded.len()].copy_from_slice(&decoded);
+            Ok(AssetId { id: asset_id })
+        })
+        .collect::<Result<Vec<AssetId>, Error>>()
+        .unwrap();
+    let valid_asset_ids = convert_asset_ids(valid_asset_ids);
+    let account_tx = AccountCreator
+        .create(&secret_account, &valid_asset_ids, &mut rng)
+        .unwrap();
+    let account_id = account_tx.pub_account.enc_asset_id.clone();
+
+    Ok(CreatAccountOutput {
+        secret_account: base64::encode(secret_account.encode()),
+        account_id: base64::encode(account_id.encode()),
+        account_tx: base64::encode(account_tx.encode()),
+    })
+}
+
+/// TODO
+///
+/// # Arguments
+/// * `todo`: todo
+///
+/// # Outputs
+/// * `todo`: todo
+///
+/// # Errors
+/// * todo
+#[wasm_bindgen]
+pub fn create_mediator_account() -> CreatMediatorAccountOutput {
+    let mut rng = OsRng;
+
+    let mediator_elg_secret_key = ElgamalSecretKey::new(Scalar::random(&mut rng));
+    let mediator_enc_key = EncryptionKeys {
+        public: mediator_elg_secret_key.get_public_key().into(),
+        secret: mediator_elg_secret_key.into(),
+    };
+
+    CreatMediatorAccountOutput {
+        public_account: base64::encode(mediator_enc_key.public.encode()),
+        secret_account: base64::encode(
+            MediatorAccount {
+                encryption_key: mediator_enc_key,
+            }
+            .encode(),
+        ),
+    }
+}
+
+/// TODO
+///
+/// # Arguments
+/// * `todo`: todo
+///
+/// # Outputs
+/// * `todo`: todo
+///
+/// # Errors
+/// * todo
+#[wasm_bindgen]
+pub fn mint_asset(amount: u32, issuer_account: Account) -> MintAssetOutput {
+    let mut rng = OsRng;
+    let asset_tx = AssetIssuer
+        .initialize_asset_transaction(&issuer_account.to_mercat(), &[], amount, &mut rng)
+        .unwrap(); // TODO
+
+    MintAssetOutput {
+        asset_tx: base64::encode(asset_tx.encode()),
+    }
+}
+
+/// TODO
+///
+/// # Arguments
+/// * `todo`: todo
+///
+/// # Outputs
+/// * `todo`: todo
+///
+/// # Errors
+/// * todo
+#[wasm_bindgen]
+pub fn create_transaction(
+    amount: u32,
+    sender_account: Account,
+    encrypted_pending_balance: Base64,
+    receiver_public_account: PubAccount,
+    mediator_public_key: Base64,
+) -> CreateTransactionOutput {
+    let mut rng = OsRng;
+
+    let decoded = base64::decode(encrypted_pending_balance).unwrap();
+    let pending_balance = CipherText::decode(&mut &decoded[..]).unwrap();
+
+    let decoded = base64::decode(mediator_public_key).unwrap();
+    let mediator_public_key = ElgamalPublicKey::decode(&mut &decoded[..]).unwrap();
+
+    let init_tx = CtxSender
+        .create_transaction(
+            &sender_account.to_mercat(),
+            &pending_balance,
+            &receiver_public_account.to_mercat(),
+            &mediator_public_key,
+            &[],
+            amount,
+            &mut rng,
+        )
+        .unwrap();
+
+    CreateTransactionOutput {
+        init_tx: base64::encode(init_tx.encode()),
+    }
+}
+
+/// TODO
+///
+/// # Arguments
+/// * `todo`: todo
+///
+/// # Outputs
+/// * `todo`: todo
+///
+/// # Errors
+/// * todo
+#[wasm_bindgen]
+pub fn finalize_transaction(
+    amount: u32,
+    init_tx: Base64,
+    receiver_account: Account,
+) -> FinalizedTransactionOutput {
+    let mut rng = OsRng;
+
+    let decoded = base64::decode(init_tx).unwrap();
+    let tx = InitializedTransferTx::decode(&mut &decoded[..]).unwrap();
+
+    let finalized_tx = CtxReceiver
+        .finalize_transaction(tx, receiver_account.to_mercat(), amount, &mut rng)
+        .unwrap();
+
+    FinalizedTransactionOutput {
+        finalized_tx: base64::encode(finalized_tx.encode()),
+    }
+}
+
+///// TODO
+/////
+///// # Arguments
+///// * `todo`: todo
+/////
+///// # Outputs
+///// * `todo`: todo
+/////
+///// # Errors
+///// * todo
+//#[wasm_bindgen]
+//pub fn justify_transaction(
+//    finalized_tx: Base64,
+//    mediator_account: MediatorAccount,
+//) -> FinalizedTransactionOutput {
+//    let mut rng = OsRng;
+//
+//    let decoded = base64::decode(finalized_tx).unwrap();
+//    let finalized_tx = FinalizedTransferTx::decode(&mut &decoded[..]).unwrap();
+//
+//    let justified_tx = CtxMediator
+//        .justify_transaction(
+//            finalized_tx,
+//            &mediator_account.encryption_key,
+//            &sender_pub_account,
+//            &sender_balance,
+//            &receiver_pub_account,
+//            &[],
+//            asset_id,
+//            &mut rng,
+//        )
+//        .unwrap();
+//
+//    FinalizedTransactionOutput {
+//        finalized_tx: base64::encode(finalized_tx.encode()),
+//    }
+//}
+
+fn create_secret_account(rng: &mut OsRng, ticker_id: String) -> Result<SecAccount, Error> {
+    let elg_secret = ElgamalSecretKey::new(Scalar::random(rng));
+    let elg_pub = elg_secret.get_public_key();
+    let enc_keys = EncryptionKeys {
+        public: elg_pub.into(),
+        secret: elg_secret.into(),
+    };
+
+    let mut asset_id = [0u8; 12];
+    let decoded = hex::decode(ticker_id).unwrap();
+    asset_id[..decoded.len()].copy_from_slice(&decoded);
+
+    let asset_id = AssetId { id: asset_id };
+    let asset_id_witness = CommitmentWitness::new(asset_id.clone().into(), Scalar::random(rng));
+
+    Ok(SecAccount {
+        enc_keys,
+        asset_id_witness,
+    })
+}

--- a/mercat/wasm/src/lib.rs
+++ b/mercat/wasm/src/lib.rs
@@ -32,6 +32,7 @@ pub type Base64 = String;
 #[wasm_bindgen]
 pub struct CreatAccountOutput {
     secret_account: Base64,
+    public_key: Base64,
     account_id: Base64,
     account_tx: Base64,
 }
@@ -41,6 +42,11 @@ impl CreatAccountOutput {
     #[wasm_bindgen(getter)]
     pub fn secret_account(&self) -> Base64 {
         self.secret_account.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn public_key(&self) -> Base64 {
+        self.public_key.clone()
     }
 
     #[wasm_bindgen(getter)]
@@ -57,7 +63,7 @@ impl CreatAccountOutput {
 #[wasm_bindgen]
 pub struct CreatMediatorAccountOutput {
     secret_account: MediatorAccount,
-    public_account: Base64,
+    public_key: Base64,
 }
 
 #[wasm_bindgen]
@@ -70,8 +76,8 @@ impl CreatMediatorAccountOutput {
     }
 
     #[wasm_bindgen(getter)]
-    pub fn public_account(&self) -> Base64 {
-        self.public_account.clone()
+    pub fn public_key(&self) -> Base64 {
+        self.public_key.clone()
     }
 }
 
@@ -261,6 +267,7 @@ pub fn create_account(
 
     Ok(CreatAccountOutput {
         secret_account: base64::encode(secret_account.encode()),
+        public_key: base64::encode(secret_account.enc_keys.public.encode()),
         account_id: base64::encode(account_id.encode()),
         account_tx: base64::encode(account_tx.encode()),
     })
@@ -287,7 +294,7 @@ pub fn create_mediator_account() -> CreatMediatorAccountOutput {
     };
 
     CreatMediatorAccountOutput {
-        public_account: base64::encode(mediator_enc_key.public.encode()),
+        public_key: base64::encode(mediator_enc_key.public.encode()),
         secret_account: MediatorAccount {
             secret: base64::encode(
                 MercatMediatorAccount {


### PR DESCRIPTION
These apis can be used by the tooling team when they integrate mercat into wallet. These can also be used for writing end-to-end js tests in polymesh.