### PR TITLE
Make clippy happier

### DIFF
--- a/confidential-identity/cli/scp/src/main.rs
+++ b/confidential-identity/cli/scp/src/main.rs
@@ -12,7 +12,6 @@ use confidential_identity::{
     ProofKeyPair, ScopeClaimData,
 };
 use curve25519_dalek::ristretto::RistrettoPoint;
-use hex;
 use rand::{rngs::StdRng, SeedableRng};
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -179,7 +178,7 @@ fn process_create_cdd_id(cfg: CreateCDDIdInfo) {
 
         raw_cdd_data
     } else {
-        let file_cdd_claim = match cfg.cdd_claim {
+        match cfg.cdd_claim {
             Some(c) => {
                 let json_file_content =
                     std::fs::read_to_string(&c).expect("Failed to read the cdd claim from file.");
@@ -188,9 +187,7 @@ fn process_create_cdd_id(cfg: CreateCDDIdInfo) {
                 })
             }
             None => panic!("You must either pass in a claim file or generate it randomly."),
-        };
-
-        file_cdd_claim
+        }
     };
 
     let cdd_claim = CddClaimData::new(&raw_cdd_data.investor_did, &raw_cdd_data.investor_unique_id);
@@ -205,7 +202,7 @@ fn process_create_cdd_id(cfg: CreateCDDIdInfo) {
     let cdd_id = compute_cdd_id(&cdd_claim);
 
     // => CDD provider includes the CDD Id in their claim and submits it to the PolyMesh.
-    let packaged_cdd_id = CddId { cdd_id: cdd_id };
+    let packaged_cdd_id = CddId { cdd_id };
     let cdd_id_str = serde_json::to_string(&packaged_cdd_id)
         .unwrap_or_else(|error| panic!("Failed to serialize the CDD Id: {}", error));
 
@@ -227,7 +224,7 @@ fn process_create_claim_proof(cfg: CreateClaimProofInfo) {
         let rand_unique_id = random_unique_id(&mut rng);
         let raw_cdd_data = RawCddClaimData {
             investor_did: rand_investor_did,
-            investor_unique_id: rand_unique_id.clone(),
+            investor_unique_id: rand_unique_id,
         };
 
         let rand_scope_did = random_scope_did(&mut rng);
@@ -319,9 +316,9 @@ fn process_create_claim_proof(cfg: CreateClaimProofInfo) {
 
     // => Investor makes {cdd_id, investor_did, scope_id, scope_did, proof} public knowledge.
     let packaged_proof = Proof {
-        cdd_id: cdd_id,
+        cdd_id,
         investor_did: raw_cdd_claim.investor_did,
-        scope_id: scope_id,
+        scope_id,
         scope_did: raw_scope_claim.scope_did,
         proof,
     };

--- a/confidential-identity/ffi/src/lib.rs
+++ b/confidential-identity/ffi/src/lib.rs
@@ -28,9 +28,12 @@ fn box_alloc<T>(x: T) -> *mut T {
 /// Create a new `CddClaimData` object.
 ///
 /// Caller is responsible for calling `cdd_claim_data_free()` to deallocate this object.
-/// SAFETY: Caller is also responsible for making sure `investor_did` and
-///         `investor_unique_id` point to allocated blocks of memory of `investor_did_size`
-///         and `investor_unique_id_size` bytes respectively.
+///
+/// # Safety
+///
+/// Caller is also responsible for making sure `investor_did` and
+/// `investor_unique_id` point to allocated blocks of memory of `investor_did_size`
+/// and `investor_unique_id_size` bytes respectively.
 #[no_mangle]
 pub unsafe extern "C" fn cdd_claim_data_new(
     investor_did: *const u8,
@@ -63,9 +66,12 @@ pub unsafe extern "C" fn cdd_claim_data_free(ptr: *mut CddClaimData) {
 /// Create a new `ScopeClaimData` object.
 ///
 /// Caller is responsible for calling `scope_claim_data_free()` to deallocate this object.
-/// SAFETY: Caller is also responsible for making sure `scope_did` and
-///         `investor_unique_id` point to allocated blocks of memory of `scope_did_size`
-///         and `investor_unique_id_size` bytes respectively.
+///
+/// # Safety
+///
+/// Caller is also responsible for making sure `scope_did` and
+/// `investor_unique_id` point to allocated blocks of memory of `scope_did_size`
+/// and `investor_unique_id_size` bytes respectively.
 #[no_mangle]
 pub unsafe extern "C" fn scope_claim_data_new(
     scope_did: *const u8,
@@ -110,11 +116,14 @@ pub unsafe extern "C" fn scope_claim_proof_data_free(ptr: *mut ScopeClaimProofDa
 /// Create a new `ProofPublicKey` object.
 ///
 /// Caller is responsible for calling `cdd_claim_data_free()` to deallocate this object.
-/// SAFETY: Caller is responsible for making sure `investor_did` and
-///         `scope_did` point to allocated blocks of memory of `investor_did_size`
-///         and `scope_did_size` bytes respectively. Caller is also responsible
-///         for making sure the `cdd_id` and `scope_id` are valid pointers, created using
-///         `compute_cdd_id_wrapper()` and `compute_scope_id_wrapper()` API.
+///
+/// # Safety
+///
+/// Caller is responsible for making sure `investor_did` and
+/// `scope_did` point to allocated blocks of memory of `investor_did_size`
+/// and `scope_did_size` bytes respectively. Caller is also responsible
+/// for making sure the `cdd_id` and `scope_id` are valid pointers, created using
+/// `compute_cdd_id_wrapper()` and `compute_scope_id_wrapper()` API.
 #[no_mangle]
 pub unsafe extern "C" fn proof_public_key_new(
     cdd_id: *mut RistrettoPoint,
@@ -170,9 +179,11 @@ pub unsafe extern "C" fn signature_free(ptr: *mut Signature) {
 
 /// Creates a `ScopeClaimProofData` object from a CDD claim and an scope claim.
 ///
-/// SAFETY: Caller is responsible to make sure `cdd_claim` and `scope_claim`
-///         pointers are valid pointers to `CddClaimData` and `ScopeClaimData`
-///         objects, created by this API.
+/// # Safety
+///
+/// Caller is responsible to make sure `cdd_claim` and `scope_claim`
+/// pointers are valid pointers to `CddClaimData` and `ScopeClaimData`
+/// objects, created by this API.
 /// Caller is responsible for deallocating memory after use.
 #[no_mangle]
 pub unsafe extern "C" fn build_scope_claim_proof_data_wrapper(
@@ -189,8 +200,10 @@ pub unsafe extern "C" fn build_scope_claim_proof_data_wrapper(
 
 /// Creates a CDD ID from a CDD claim.
 ///
-/// SAFETY: Caller is responsible to make sure `cdd_claim` pointer is a valid
-///         `CddClaimData` object, created by this API.
+/// # Safety
+///
+/// Caller is responsible to make sure `cdd_claim` pointer is a valid
+/// `CddClaimData` object, created by this API.
 /// Caller is responsible for deallocating memory after use.
 #[no_mangle]
 pub unsafe extern "C" fn compute_cdd_id_wrapper(
@@ -204,8 +217,10 @@ pub unsafe extern "C" fn compute_cdd_id_wrapper(
 
 /// Creates a scope ID from a scope claim.
 ///
-/// SAFETY: Caller is responsible to make sure the `scope_claim` pointer is a valid
-///         `ScopeClaimData` object, created by this API.
+/// # Saftey
+///
+/// Caller is responsible to make sure the `scope_claim` pointer is a valid
+/// `ScopeClaimData` object, created by this API.
 /// Caller is responsible for deallocating memory after use.
 #[no_mangle]
 pub unsafe extern "C" fn compute_scope_id_wrapper(
@@ -219,9 +234,11 @@ pub unsafe extern "C" fn compute_scope_id_wrapper(
 
 /// Creates a `Signature` from a scope claim proof data and a message.
 ///
-/// SAFETY: Caller is responsible to make sure `scope_claim_proof_data` and `message`
-///         pointers are valid objects, created by this API, and `message` points to
-///         a block of memory that has at least `message_size` bytes.
+/// # Saftey
+///
+/// Caller is responsible to make sure `scope_claim_proof_data` and `message`
+/// pointers are valid objects, created by this API, and `message` points to
+/// a block of memory that has at least `message_size` bytes.
 /// Caller is responsible for deallocating memory after use.
 #[no_mangle]
 pub unsafe extern "C" fn generate_id_match_proof_wrapper(
@@ -247,9 +264,11 @@ pub unsafe extern "C" fn generate_id_match_proof_wrapper(
 
 /// Verifies the signature on a message.
 ///
-/// SAFETY: Caller is responsible to make sure `proof_public_key`, `message`, and `signature`
-///         pointers are valid objects, created by this API, and `message` points to a block
-///         of memory that has at least `message_size` bytes.
+/// # Safety
+///
+/// Caller is responsible to make sure `proof_public_key`, `message`, and `signature`
+/// pointers are valid objects, created by this API, and `message` points to a block
+/// of memory that has at least `message_size` bytes.
 /// Caller is responsible for deallocating memory after use.
 #[no_mangle]
 pub unsafe extern "C" fn verify_id_match_proof_wrapper(

--- a/confidential-identity/wasm/src/lib.rs
+++ b/confidential-identity/wasm/src/lib.rs
@@ -4,7 +4,6 @@ use confidential_identity::{
     ProofKeyPair, ScopeClaimData,
 };
 use curve25519_dalek::ristretto::RistrettoPoint;
-use hex;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
@@ -70,7 +69,7 @@ pub fn process_create_cdd_id(cdd_claim: String) -> Result<String, JsValue> {
 
     let cdd_id = compute_cdd_id(&cdd_claim);
 
-    let packaged_cdd_id = CddId { cdd_id: cdd_id };
+    let packaged_cdd_id = CddId { cdd_id };
     let cdd_id_str = serde_json::to_string(&packaged_cdd_id)
         .map_err(|error| format!("Failed to serialize the CDD Id: {}", error))?;
 
@@ -120,9 +119,9 @@ pub fn process_create_claim_proof(
 
     // => Investor makes {cdd_id, investor_did, scope_id, scope_did, proof} public knowledge.
     let packaged_proof = Proof {
-        cdd_id: cdd_id,
+        cdd_id,
         investor_did: raw_cdd_claim.investor_did,
-        scope_id: scope_id,
+        scope_id,
         scope_did: raw_scope_claim.scope_did,
         proof,
     };

--- a/cryptography-core/src/asset_proofs/one_out_of_many_proof.rs
+++ b/cryptography-core/src/asset_proofs/one_out_of_many_proof.rs
@@ -831,8 +831,8 @@ impl<'a> AssetProofProverAwaitingChallenge for OOONProverAwaitingChallenge<'a> {
         for i in 0..n {
             polynomials.push(one.clone());
             let i_rep = convert_to_base(i, self.base as usize, exp);
-            for k in 0..self.exp as usize {
-                let t = k * self.base as usize + i_rep[k];
+            for (k, item) in i_rep.iter().enumerate().take(self.exp as usize) {
+                let t = k * self.base as usize + item;
                 polynomials[i].add_factor(l_bit_matrix[t], r1_prover.a_values[t]);
             }
         }
@@ -840,8 +840,8 @@ impl<'a> AssetProofProverAwaitingChallenge for OOONProverAwaitingChallenge<'a> {
         let mut G_values: Vec<RistrettoPoint> = Vec::with_capacity(self.exp as usize);
         for k in 0..self.exp as usize {
             G_values.push(rho[k] * generators.com_gens.B_blinding); // #TODO: Double check if this matches the El-Gamal generators.
-            for i in 0..n {
-                G_values[k] += (polynomials[i].coeffs[k]) * self.commitments[i];
+            for (i, polynomial) in polynomials.iter().enumerate().take(n) {
+                G_values[k] += (polynomial.coeffs[k]) * self.commitments[i];
             }
         }
 

--- a/cryptography-core/src/asset_proofs/one_out_of_many_proof.rs
+++ b/cryptography-core/src/asset_proofs/one_out_of_many_proof.rs
@@ -839,7 +839,7 @@ impl<'a> AssetProofProverAwaitingChallenge for OOONProverAwaitingChallenge<'a> {
 
         let mut G_values: Vec<RistrettoPoint> = Vec::with_capacity(self.exp as usize);
         for k in 0..self.exp as usize {
-            G_values.push(rho[k] * generators.com_gens.B_blinding); // #TODO: Double check if this matches the El-Gamal generators.
+            G_values.push(rho[k] * generators.com_gens.B_blinding);
             for (i, polynomial) in polynomials.iter().enumerate().take(n) {
                 G_values[k] += (polynomial.coeffs[k]) * self.commitments[i];
             }

--- a/mercat/cli/common/src/account_issue.rs
+++ b/mercat/cli/common/src/account_issue.rs
@@ -3,7 +3,6 @@ use crate::{
     save_object, user_public_account_file, user_secret_account_file, OrderedAssetInstruction,
     OrderedPubAccount, OrderingState, COMMON_OBJECTS_DIR, OFF_CHAIN_DIR, ON_CHAIN_DIR,
 };
-use base64;
 use codec::Encode;
 use cryptography_core::{asset_id_from_ticker, asset_proofs::CommitmentWitness};
 use curve25519_dalek::scalar::Scalar;
@@ -104,10 +103,9 @@ pub fn process_issue_asset(
         let cheat_asset_id =
             asset_id_from_ticker("CHEAT").map_err(|error| Error::LibraryError { error })?;
         let cheat_asset_id_witness =
-            CommitmentWitness::new(cheat_asset_id.clone().into(), Scalar::random(&mut rng));
+            CommitmentWitness::new(cheat_asset_id.into(), Scalar::random(&mut rng));
         let cheat_enc_asset_id = issuer_account
             .secret
-            .clone()
             .enc_keys
             .public
             .encrypt(&cheat_asset_id_witness);

--- a/mercat/cli/common/src/account_transfer.rs
+++ b/mercat/cli/common/src/account_transfer.rs
@@ -6,7 +6,6 @@ use crate::{
     PrintableAccountId, COMMON_OBJECTS_DIR, MEDIATOR_PUBLIC_ACCOUNT_FILE, OFF_CHAIN_DIR,
     ON_CHAIN_DIR,
 };
-use base64;
 use codec::{Decode, Encode};
 use log::{debug, info};
 use mercat::{
@@ -99,7 +98,7 @@ pub fn process_create_tx(
         tx_id,
         debug_decrypt(
             sender_account.public.enc_asset_id,
-            pending_balance.clone(),
+            pending_balance,
             db_dir.clone()
         )?
     );
@@ -234,7 +233,7 @@ pub fn process_finalize_tx(
         db_dir.clone(),
         ON_CHAIN_DIR,
         COMMON_OBJECTS_DIR,
-        &confidential_transaction_file(tx_id.clone(), &sender, state),
+        &confidential_transaction_file(tx_id, &sender, state),
     )?;
 
     let tx = InitializedTransferTx::decode(&mut &instruction.data[..]).map_err(|error| {
@@ -244,7 +243,7 @@ pub fn process_finalize_tx(
                 db_dir.clone(),
                 ON_CHAIN_DIR,
                 &sender.clone(),
-                &confidential_transaction_file(tx_id.clone(), &sender, state),
+                &confidential_transaction_file(tx_id, &sender, state),
             ),
         }
     })?;

--- a/mercat/cli/common/src/errors.rs
+++ b/mercat/cli/common/src/errors.rs
@@ -1,4 +1,3 @@
-use crate::CoreTransaction;
 use failure::Fail;
 use std::path::PathBuf;
 
@@ -130,8 +129,8 @@ pub enum Error {
     InvalidTransactionFile { path: String },
 
     /// Transaction is not ready for validation
-    #[fail(display = "Transaction is not ready for validation: {:?}.", tx)]
-    TransactionIsNotReadyForValidation { tx: CoreTransaction },
+    #[fail(display = "Transaction is not ready for validation.")]
+    TransactionIsNotReadyForValidation,
 
     /// Last transaction could not be found for user.
     #[fail(display = "Last transaction could not be found for user: {:?}.", user)]

--- a/mercat/cli/common/src/justify.rs
+++ b/mercat/cli/common/src/justify.rs
@@ -5,7 +5,6 @@ use crate::{
     OrderedTransferInstruction, TransferInstruction, COMMON_OBJECTS_DIR,
     MEDIATOR_PUBLIC_ACCOUNT_FILE, OFF_CHAIN_DIR, ON_CHAIN_DIR, SECRET_ACCOUNT_FILE,
 };
-use base64;
 use codec::{Decode, Encode};
 use cryptography_core::{asset_id_from_ticker, asset_proofs::ElgamalSecretKey};
 use curve25519_dalek::scalar::Scalar;
@@ -23,8 +22,8 @@ fn generate_mediator_keys<R: RngCore + CryptoRng>(
 ) -> (EncryptionPubKey, MediatorAccount) {
     let mediator_elg_secret_key = ElgamalSecretKey::new(Scalar::random(rng));
     let mediator_enc_key = EncryptionKeys {
-        public: mediator_elg_secret_key.get_public_key().into(),
-        secret: mediator_elg_secret_key.into(),
+        public: mediator_elg_secret_key.get_public_key(),
+        secret: mediator_elg_secret_key,
     };
 
     (
@@ -129,7 +128,7 @@ pub fn justify_asset_transfer_transaction(
     let sender_ordered_pub_account: OrderedPubAccount = load_object(
         db_dir.clone(),
         ON_CHAIN_DIR,
-        &sender.clone(),
+        &sender,
         &user_public_account_file(&ticker),
     )?;
     let sender_account_balance: EncryptedAmount = load_object(
@@ -142,7 +141,7 @@ pub fn justify_asset_transfer_transaction(
     let receiver_ordered_pub_account: OrderedPubAccount = load_object(
         db_dir.clone(),
         ON_CHAIN_DIR,
-        &receiver.clone(),
+        &receiver,
         &user_public_account_file(&ticker),
     )?;
 
@@ -215,7 +214,7 @@ pub fn justify_asset_transfer_transaction(
         };
 
         save_object(
-            db_dir.clone(),
+            db_dir,
             ON_CHAIN_DIR,
             COMMON_OBJECTS_DIR,
             &confidential_transaction_file(tx_id, &sender, rejected_state),

--- a/private-identity-audit/src/proofs.rs
+++ b/private-identity-audit/src/proofs.rs
@@ -52,18 +52,12 @@ pub fn generate_initial_message<T: RngCore + CryptoRng>(
         .map(|(gen, rand)| gen * rand)
         .fold_first(|v1, v2| v1 + v2)
         .ok_or(ErrorKind::InitialMessageGenError)?;
-    Ok((
-        Secrets { rands, secrets },
-        InitialMessage {
-            a,
-            generators: generators.clone(),
-        },
-    ))
+    Ok((Secrets { rands, secrets }, InitialMessage { a, generators }))
 }
 
 pub fn apply_challenge(prover_secrets: Secrets, c: Challenge) -> FinalResponse {
     let s = (&prover_secrets.rands)
-        .into_iter()
+        .iter()
         .zip(&prover_secrets.secrets)
         .map(|(rand, secret)| rand + c * secret)
         .collect();

--- a/private-identity-audit/src/verifier.rs
+++ b/private-identity-audit/src/verifier.rs
@@ -32,7 +32,7 @@ impl ChallengeGenerator for VerifierSetGenerator {
             let padding: Vec<Scalar> =
                 gen_random_uuids(min_size - private_unique_identifiers.len(), rng)
                     .into_iter()
-                    .map(|uuid| uuid_to_scalar(uuid))
+                    .map(uuid_to_scalar)
                     .collect();
             [&private_unique_identifiers[..], &padding[..]].concat()
         };


### PR DESCRIPTION
Fixed a bunch of clippy warnings. The ones left are typically around
1. Function having too many inputs
2. unsafe functions missing `# Safety` section
3. Big difference in size of different enum members