### PR TITLE
update the ffi wrappers

### DIFF
--- a/confidential-identity/ffi/Cargo.toml
+++ b/confidential-identity/ffi/Cargo.toml
@@ -20,7 +20,8 @@ path = ".."
 [dependencies]
 libc = "^0.2"
 curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly", "u64_backend"] }
-schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false }
+rand = { version = "0.7.3", features = ["wasm-bindgen", "getrandom", "alloc"], default-features = false }
+rand_core = { version = "0.5", default-features = false}
 
 [build-dependencies]
 cbindgen = { version = "^0.13", optional = true }

--- a/confidential-identity/ffi/confidential_identity.h
+++ b/confidential-identity/ffi/confidential_identity.h
@@ -16,25 +16,16 @@ typedef struct CddClaimData CddClaimData;
 typedef struct CddId CddId;
 
 /**
- * An Schnorrkel/Ristretto x25519 ("sr25519") public key.
- * This is the construct that the blockchain validator will use for
- * claim proof validation.
- */
-typedef struct ProofPublicKey ProofPublicKey;
-
-/**
  * The data needed to generate a SCOPE ID.
  */
 typedef struct ScopeClaimData ScopeClaimData;
 
 /**
- * The data needed to generate a proof that a SCOPE ID matches a CDD ID
+ * Contains the Zero Knowledge proof and the proof of wellformedness.
+ * This is the construct that the investors will use to generate
+ * claim proofs.
  */
-typedef struct ScopeClaimProofData ScopeClaimProofData;
-
-typedef struct RistrettoPoint RistrettoPoint;
-
-typedef struct Signature Signature;
+typedef struct ScopeClaimProof ScopeClaimProof;
 
 /**
  * Create a new `CddClaimData` object.
@@ -85,63 +76,6 @@ ScopeClaimData *scope_claim_data_new(const uint8_t *scope_did,
 void scope_claim_data_free(ScopeClaimData *ptr);
 
 /**
- * Deallocates a `ScopeClaimProofData` object's memory.
- *
- * Should only be called on a still-valid pointer to an object returned by
- * `build_scope_claim_proof_data_wrapper()`.
- */
-void scope_claim_proof_data_free(ScopeClaimProofData *ptr);
-
-/**
- * Create a new `ProofPublicKey` object.
- *
- * Caller is responsible for calling `cdd_claim_data_free()` to deallocate this object.
- *
- * # Safety
- *
- * Caller is responsible for making sure `investor_did` and
- * `scope_did` point to allocated blocks of memory of `investor_did_size`
- * and `scope_did_size` bytes respectively. Caller is also responsible
- * for making sure the `cdd_id` and `scope_id` are valid pointers, created using
- * `compute_cdd_id_wrapper()` and `compute_scope_id_wrapper()` API.
- */
-ProofPublicKey *proof_public_key_new(CddId *cdd_id,
-                                     const uint8_t *investor_did,
-                                     size_t investor_did_size,
-                                     RistrettoPoint *scope_id,
-                                     const uint8_t *scope_did,
-                                     size_t scope_did_size);
-
-/**
- * Deallocates a `ProofPublicKey` object's memory.
- *
- * Should only be called on a still-valid pointer to an object returned by
- * `proof_public_key_new()`.
- */
-void proof_public_key_free(ProofPublicKey *ptr);
-
-/**
- * Deallocates a `Signature` object's memory.
- *
- * Should only be called on a still-valid pointer to an object returned by
- * `generate_id_match_proof_wrapper()`.
- */
-void signature_free(Signature *ptr);
-
-/**
- * Creates a `ScopeClaimProofData` object from a CDD claim and an scope claim.
- *
- * # Safety
- *
- * Caller is responsible to make sure `cdd_claim` and `scope_claim`
- * pointers are valid pointers to `CddClaimData` and `ScopeClaimData`
- * objects, created by this API.
- * Caller is responsible for deallocating memory after use.
- */
-ScopeClaimProofData *build_scope_claim_proof_data_wrapper(const CddClaimData *cdd_claim,
-                                                          const ScopeClaimData *scope_claim);
-
-/**
  * Creates a CDD ID from a CDD claim.
  *
  * # Safety
@@ -150,18 +84,7 @@ ScopeClaimProofData *build_scope_claim_proof_data_wrapper(const CddClaimData *cd
  * `CddClaimData` object, created by this API.
  * Caller is responsible for deallocating memory after use.
  */
-CddId *compute_cdd_id_wrapper(const CddClaimData *cdd_claim);
-
-/**
- * Creates a scope ID from a scope claim.
- *
- * # Safety
- *
- * Caller is responsible to make sure the `scope_claim` pointer is a valid
- * `ScopeClaimData` object, created by this API.
- * Caller is responsible for deallocating memory after use.
- */
-RistrettoPoint *compute_scope_id_wrapper(const ScopeClaimData *scope_claim);
+CddId *create_cdd_id(const CddClaimData *cdd_claim);
 
 /**
  * Creates a `Signature` from a scope claim proof data and a message.
@@ -173,9 +96,16 @@ RistrettoPoint *compute_scope_id_wrapper(const ScopeClaimData *scope_claim);
  * a block of memory that has at least `message_size` bytes.
  * Caller is responsible for deallocating memory after use.
  */
-Signature *generate_id_match_proof_wrapper(ScopeClaimProofData *scope_claim_proof_data,
-                                           const uint8_t *message,
-                                           size_t message_size);
+struct ScopeClaimProof *create_scope_claim_proof(const CddClaimData *cdd_claim,
+                                                 const ScopeClaimData *scope_claim);
+
+/**
+ * Deallocates a `ScopeClaimProof` object's memory.
+ *
+ * Should only be called on a still-valid pointer to an object returned by
+ * `cdd_claim_data_new()`.
+ */
+void scope_claim_proof_free(struct ScopeClaimProof *ptr);
 
 /**
  * Verifies the signature on a message.
@@ -187,9 +117,8 @@ Signature *generate_id_match_proof_wrapper(ScopeClaimProofData *scope_claim_proo
  * of memory that has at least `message_size` bytes.
  * Caller is responsible for deallocating memory after use.
  */
-bool verify_id_match_proof_wrapper(const ProofPublicKey *proof_public_key,
-                                   const uint8_t *message,
-                                   size_t message_size,
-                                   const Signature *signature);
+bool verify_scope_claim_proof(const struct ScopeClaimProof *proof,
+                              const uint8_t *investor_did,
+                              const CddId *cdd_id);
 
 #endif /* confidential_identity_ffi_h */

--- a/confidential-identity/ffi/confidential_identity.h
+++ b/confidential-identity/ffi/confidential_identity.h
@@ -119,6 +119,7 @@ void scope_claim_proof_free(struct ScopeClaimProof *ptr);
  */
 bool verify_scope_claim_proof(const struct ScopeClaimProof *proof,
                               const uint8_t *investor_did,
+                              size_t investor_did_size,
                               const CddId *cdd_id);
 
 #endif /* confidential_identity_ffi_h */

--- a/confidential-identity/ffi/examples/c_example.c
+++ b/confidential-identity/ffi/examples/c_example.c
@@ -3,7 +3,6 @@
 #include <inttypes.h>
 #include <string.h>
 #include "../confidential_identity.h"
-#include "confidential_identity.h"
 
 int main(void) {
     uint8_t investor_did[32] = {0x49, 0x99, 0x52, 0x43, 0x74, 0x8c, 0x4a, 0xe7,
@@ -21,22 +20,17 @@ int main(void) {
         0x9d, 0x24, 0x72, 0xfd, 0xc9, 0x29, 0x44, 0x2b, 0x6, 0xf, 0xd, 0xa};
     size_t scope_did_size = sizeof(scope_did);
 
-    uint8_t message[] = {0x01, 0x02, 0x03};
-    size_t message_size = sizeof(message);
 
-    // Set up on Prover side:
+    // Set up on claim data side:
     CddClaimData *cdd_claim = cdd_claim_data_new(investor_did, investor_did_size, investor_unique_id, investor_unique_id_size);
     ScopeClaimData *scope_claim = scope_claim_data_new(scope_did, scope_did_size, investor_unique_id, investor_unique_id_size);
-    ScopeClaimProofData *prover = build_scope_claim_proof_data_wrapper(cdd_claim, scope_claim);
 
     // Create Proof.
-    Signature *sig = generate_id_match_proof_wrapper(prover, message, message_size);
-    CddId *cdd_id = compute_cdd_id_wrapper(cdd_claim);
-    RistrettoPoint *scope_id = compute_scope_id_wrapper(scope_claim);
+    CddId *cdd_id = create_cdd_id(cdd_claim);
+    ScopeClaimProof *proof = create_scope_claim_proof(cdd_claim, scope_claim);
 
     // Set up on the Verifier side:
-    ProofPublicKey *pub_key = proof_public_key_new(cdd_id, investor_did, investor_did_size, scope_id, scope_did, scope_did_size);
-    bool result = verify_id_match_proof_wrapper(pub_key, message, message_size, sig);
+    bool result = verify_scope_claim_proof(proof, investor_did, cdd_id);
     printf("Verification result: %d\n", result);
 
     // Cleanup.
@@ -44,7 +38,5 @@ int main(void) {
     memset_s(investor_unique_id, investor_unique_id_size, 0, investor_unique_id_size);
     cdd_claim_data_free(cdd_claim);
     scope_claim_data_free(scope_claim);
-    scope_claim_proof_data_free(prover);
-    proof_public_key_free(pub_key);
-    signature_free(sig);
+    scope_claim_proof_free(proof);
 }

--- a/confidential-identity/ffi/examples/c_example.c
+++ b/confidential-identity/ffi/examples/c_example.c
@@ -30,12 +30,12 @@ int main(void) {
     ScopeClaimProof *proof = create_scope_claim_proof(cdd_claim, scope_claim);
 
     // Set up on the Verifier side:
-    bool result = verify_scope_claim_proof(proof, investor_did, cdd_id);
+    bool result = verify_scope_claim_proof(proof, investor_did, investor_unique_id_size, cdd_id);
     printf("Verification result: %d\n", result);
 
     // Cleanup.
     // Investor's unique id is sensitive data, it's a good practice to zeroize it at cleanup.
-    memset_s(investor_unique_id, investor_unique_id_size, 0, investor_unique_id_size);
+    memset(investor_unique_id, 0, investor_unique_id_size);
     cdd_claim_data_free(cdd_claim);
     scope_claim_data_free(scope_claim);
     scope_claim_proof_free(proof);

--- a/confidential-identity/ffi/src/lib.rs
+++ b/confidential-identity/ffi/src/lib.rs
@@ -4,18 +4,18 @@
 //! Asset Granularity Unique Identity project.
 
 extern crate libc;
+use confidential_identity::{
+    claim_proofs::{Investor, Provider, Verifier},
+    cryptography_core::cdd_claim::cdd_claim_data::slice_to_scalar,
+    InvestorTrait, ProviderTrait, ScopeClaimProof, VerifierTrait,
+};
 use libc::size_t;
+use rand_core::OsRng;
 use std::slice;
 
-use confidential_identity::{build_scope_claim_proof_data, compute_cdd_id, compute_scope_id};
-
 pub type ScopeClaimData = confidential_identity::ScopeClaimData;
-pub type ScopeClaimProofData = confidential_identity::ScopeClaimProofData;
-pub type ProofPublicKey = confidential_identity::ProofPublicKey;
-pub type ProofKeyPair = confidential_identity::ProofKeyPair;
 pub type CddClaimData = confidential_identity::CddClaimData;
 pub type CddId = confidential_identity::CddId;
-pub type Signature = schnorrkel::Signature;
 pub type RistrettoPoint = curve25519_dalek::ristretto::RistrettoPoint;
 
 fn box_alloc<T>(x: T) -> *mut T {
@@ -102,102 +102,9 @@ pub unsafe extern "C" fn scope_claim_data_free(ptr: *mut ScopeClaimData) {
     Box::from_raw(ptr);
 }
 
-/// Deallocates a `ScopeClaimProofData` object's memory.
-///
-/// Should only be called on a still-valid pointer to an object returned by
-/// `build_scope_claim_proof_data_wrapper()`.
-#[no_mangle]
-pub unsafe extern "C" fn scope_claim_proof_data_free(ptr: *mut ScopeClaimProofData) {
-    if ptr.is_null() {
-        return;
-    }
-    Box::from_raw(ptr);
-}
-
-/// Create a new `ProofPublicKey` object.
-///
-/// Caller is responsible for calling `cdd_claim_data_free()` to deallocate this object.
-///
-/// # Safety
-///
-/// Caller is responsible for making sure `investor_did` and
-/// `scope_did` point to allocated blocks of memory of `investor_did_size`
-/// and `scope_did_size` bytes respectively. Caller is also responsible
-/// for making sure the `cdd_id` and `scope_id` are valid pointers, created using
-/// `compute_cdd_id_wrapper()` and `compute_scope_id_wrapper()` API.
-#[no_mangle]
-pub unsafe extern "C" fn proof_public_key_new(
-    cdd_id: *mut CddId,
-    investor_did: *const u8,
-    investor_did_size: size_t,
-    scope_id: *mut RistrettoPoint,
-    scope_did: *const u8,
-    scope_did_size: size_t,
-) -> *mut ProofPublicKey {
-    assert!(!cdd_id.is_null());
-    assert!(!investor_did.is_null());
-    assert!(!scope_id.is_null());
-    assert!(!scope_did.is_null());
-
-    let cdd_id: CddId = *cdd_id;
-    let investor_did = slice::from_raw_parts(investor_did, investor_did_size as usize);
-    let scope_id: RistrettoPoint = *scope_id;
-    let scope_did = slice::from_raw_parts(scope_did, scope_did_size as usize);
-
-    let proof_public_key = ProofPublicKey::new(cdd_id, investor_did, scope_id, scope_did);
-
-    box_alloc(proof_public_key)
-}
-
-/// Deallocates a `ProofPublicKey` object's memory.
-///
-/// Should only be called on a still-valid pointer to an object returned by
-/// `proof_public_key_new()`.
-#[no_mangle]
-pub unsafe extern "C" fn proof_public_key_free(ptr: *mut ProofPublicKey) {
-    if ptr.is_null() {
-        return;
-    }
-
-    Box::from_raw(ptr);
-}
-
-/// Deallocates a `Signature` object's memory.
-///
-/// Should only be called on a still-valid pointer to an object returned by
-/// `generate_id_match_proof_wrapper()`.
-#[no_mangle]
-pub unsafe extern "C" fn signature_free(ptr: *mut Signature) {
-    if ptr.is_null() {
-        return;
-    }
-    Box::from_raw(ptr);
-}
-
 // ------------------------------------------------------------------------
-// Prover API
+// Provider API
 // ------------------------------------------------------------------------
-
-/// Creates a `ScopeClaimProofData` object from a CDD claim and an scope claim.
-///
-/// # Safety
-///
-/// Caller is responsible to make sure `cdd_claim` and `scope_claim`
-/// pointers are valid pointers to `CddClaimData` and `ScopeClaimData`
-/// objects, created by this API.
-/// Caller is responsible for deallocating memory after use.
-#[no_mangle]
-pub unsafe extern "C" fn build_scope_claim_proof_data_wrapper(
-    cdd_claim: *const CddClaimData,
-    scope_claim: *const ScopeClaimData,
-) -> *mut ScopeClaimProofData {
-    assert!(!cdd_claim.is_null());
-    assert!(!scope_claim.is_null());
-
-    let cdd_claim: CddClaimData = *cdd_claim;
-    let scope_claim: ScopeClaimData = *scope_claim;
-    box_alloc(build_scope_claim_proof_data(&cdd_claim, &scope_claim))
-}
 
 /// Creates a CDD ID from a CDD claim.
 ///
@@ -207,29 +114,16 @@ pub unsafe extern "C" fn build_scope_claim_proof_data_wrapper(
 /// `CddClaimData` object, created by this API.
 /// Caller is responsible for deallocating memory after use.
 #[no_mangle]
-pub unsafe extern "C" fn compute_cdd_id_wrapper(cdd_claim: *const CddClaimData) -> *mut CddId {
+pub unsafe extern "C" fn create_cdd_id(cdd_claim: *const CddClaimData) -> *mut CddId {
     assert!(!cdd_claim.is_null());
 
     let cdd_claim: CddClaimData = *cdd_claim;
-    box_alloc(compute_cdd_id(&cdd_claim))
+    box_alloc(Provider::create_cdd_id(&cdd_claim))
 }
 
-/// Creates a scope ID from a scope claim.
-///
-/// # Safety
-///
-/// Caller is responsible to make sure the `scope_claim` pointer is a valid
-/// `ScopeClaimData` object, created by this API.
-/// Caller is responsible for deallocating memory after use.
-#[no_mangle]
-pub unsafe extern "C" fn compute_scope_id_wrapper(
-    scope_claim: *const ScopeClaimData,
-) -> *mut RistrettoPoint {
-    assert!(!scope_claim.is_null());
-
-    let scope_claim: ScopeClaimData = *scope_claim;
-    box_alloc(compute_scope_id(&scope_claim))
-}
+// ------------------------------------------------------------------------
+// Verifier API
+// ------------------------------------------------------------------------
 
 /// Creates a `Signature` from a scope claim proof data and a message.
 ///
@@ -240,21 +134,31 @@ pub unsafe extern "C" fn compute_scope_id_wrapper(
 /// a block of memory that has at least `message_size` bytes.
 /// Caller is responsible for deallocating memory after use.
 #[no_mangle]
-pub unsafe extern "C" fn generate_id_match_proof_wrapper(
-    scope_claim_proof_data: *mut ScopeClaimProofData,
-    message: *const u8,
-    message_size: size_t,
-) -> *mut Signature {
-    assert!(!scope_claim_proof_data.is_null());
-    assert!(!message.is_null());
-    // We allow zero size messages.
+pub unsafe extern "C" fn create_scope_claim_proof(
+    cdd_claim: *const CddClaimData,
+    scope_claim: *const ScopeClaimData,
+) -> *mut ScopeClaimProof {
+    assert!(!cdd_claim.is_null());
+    assert!(!scope_claim.is_null());
 
-    let message_slice = slice::from_raw_parts(message, message_size as usize);
-    let scope_claim_proof_data: ScopeClaimProofData = *scope_claim_proof_data;
-    let pair = ProofKeyPair::from(scope_claim_proof_data);
-    let proof = pair.generate_id_match_proof(message_slice);
+    let mut rng = OsRng;
+    let cdd_claim: CddClaimData = *cdd_claim;
+    let scope_claim: ScopeClaimData = *scope_claim;
+    let proof = Investor::create_scope_claim_proof(&cdd_claim, &scope_claim, &mut rng);
 
     box_alloc(proof)
+}
+
+/// Deallocates a `ScopeClaimProof` object's memory.
+///
+/// Should only be called on a still-valid pointer to an object returned by
+/// `cdd_claim_data_new()`.
+#[no_mangle]
+pub unsafe extern "C" fn scope_claim_proof_free(ptr: *mut ScopeClaimProof) {
+    if ptr.is_null() {
+        return;
+    }
+    Box::from_raw(ptr);
 }
 
 // ------------------------------------------------------------------------
@@ -270,19 +174,17 @@ pub unsafe extern "C" fn generate_id_match_proof_wrapper(
 /// of memory that has at least `message_size` bytes.
 /// Caller is responsible for deallocating memory after use.
 #[no_mangle]
-pub unsafe extern "C" fn verify_id_match_proof_wrapper(
-    proof_public_key: *const ProofPublicKey,
-    message: *const u8,
-    message_size: size_t,
-    signature: *const Signature,
+pub unsafe extern "C" fn verify_scope_claim_proof(
+    proof: *const ScopeClaimProof,
+    investor_did: *const u8,
+    cdd_id: *const CddId,
 ) -> bool {
-    assert!(!proof_public_key.is_null());
-    assert!(!message.is_null());
-    // We allow zero size messages.
+    assert!(!proof.is_null());
+    assert!(!investor_did.is_null());
+    assert!(!cdd_id.is_null());
 
-    let message_slice = slice::from_raw_parts(message, message_size as usize);
-    let proof_public_key: ProofPublicKey = *proof_public_key;
-    let signature: Signature = *signature;
-
-    proof_public_key.verify_id_match_proof(message_slice, &signature)
+    let proof: &ScopeClaimProof = &*proof;
+    let investor_did = slice_to_scalar(slice::from_raw_parts(investor_did, investor_did as usize));
+    let cdd_id: CddId = *cdd_id;
+    Verifier::verify_scope_claim_proof(proof, &investor_did, &cdd_id).is_ok()
 }

--- a/confidential-identity/ffi/src/lib.rs
+++ b/confidential-identity/ffi/src/lib.rs
@@ -177,6 +177,7 @@ pub unsafe extern "C" fn scope_claim_proof_free(ptr: *mut ScopeClaimProof) {
 pub unsafe extern "C" fn verify_scope_claim_proof(
     proof: *const ScopeClaimProof,
     investor_did: *const u8,
+    investor_did_size: size_t,
     cdd_id: *const CddId,
 ) -> bool {
     assert!(!proof.is_null());
@@ -184,7 +185,8 @@ pub unsafe extern "C" fn verify_scope_claim_proof(
     assert!(!cdd_id.is_null());
 
     let proof: &ScopeClaimProof = &*proof;
-    let investor_did = slice_to_scalar(slice::from_raw_parts(investor_did, investor_did as usize));
+    let investor_did = slice::from_raw_parts(investor_did, investor_did_size as usize);
+    let investor_did = slice_to_scalar(investor_did);
     let cdd_id: CddId = *cdd_id;
     Verifier::verify_scope_claim_proof(proof, &investor_did, &cdd_id).is_ok()
 }

--- a/confidential-identity/src/claim_proofs.rs
+++ b/confidential-identity/src/claim_proofs.rs
@@ -2,6 +2,7 @@
 //! claim proofs and verifying them as part of the
 //! Asset Granularity Unique Identity project.
 //!
+//! TODO: update all the docs!!!
 //! The investor would use the `Proof` API to generate
 //! the proofs.
 //!

--- a/confidential-identity/src/lib.rs
+++ b/confidential-identity/src/lib.rs
@@ -9,6 +9,7 @@
 extern crate alloc;
 
 pub use claim_proofs::{CddClaimData, CddId, ScopeClaimData, ScopeClaimProof, ScopeClaimProofData};
+pub use cryptography_core;
 pub use curve25519_dalek::{
     self,
     ristretto::{CompressedRistretto, RistrettoPoint},

--- a/cryptography-core/src/cdd_claim/cdd_claim_data.rs
+++ b/cryptography-core/src/cdd_claim/cdd_claim_data.rs
@@ -9,7 +9,7 @@ use curve25519_dalek::{
 use serde::{Deserialize, Serialize};
 
 /// Create a scalar from a slice of data.
-fn slice_to_scalar(data: &[u8]) -> Scalar {
+pub fn slice_to_scalar(data: &[u8]) -> Scalar {
     use blake2::{Blake2b, Digest};
     let mut hash = [0u8; 64];
     hash.copy_from_slice(Blake2b::digest(data).as_slice());


### PR DESCRIPTION
https://polymath.atlassian.net/browse/CRYP-215

Changed `memset_s` to `memset` in the example code to make it compile on my machine.

-----------------


The compile command did not run on my machine (ubuntu 20.04):

```
cryptography/confidential-identity/ffi
▶ gcc examples/c_example.c -I include -L../../target/release/ -l confidential_identity_ffi -o example.out
examples/c_example.c: In function ‘main’:
examples/c_example.c:38:5: warning: implicit declaration of function ‘memset_s’; did you mean ‘memset’? [-Wimplicit-function-declaration]
   38 |     memset_s(investor_unique_id, investor_unique_id_size, 0, investor_unique_id_size);
      |     ^~~~~~~~
      |     memset
/usr/bin/ld: cannot find -lconfidential_identity_ffi
collect2: error: ld returned 1 exit status
```
